### PR TITLE
Clarify bass mirror melody option

### DIFF
--- a/docs/arrangement_features.md
+++ b/docs/arrangement_features.md
@@ -16,6 +16,15 @@ bass_part:
 
 If disabled or omitted, the bass follows its normal pattern selection based on emotion buckets and intensity.
 
+You can enable this behaviour for all sections by adding `mirror_melody: true`
+under `part_defaults.bass` in your `main_cfg.yml`:
+
+```yaml
+part_defaults:
+  bass:
+    mirror_melody: true
+```
+
 ## `guitar_emotion_arpeggio` Rhythm Key
 
 The rhythm library includes a pattern named `guitar_emotion_arpeggio`. It selects arpeggio note ordering depending on the current emotion bucket. Each bucket (e.g., `calm`, `groovy`, `energetic`) maps to a different set of arpeggio indices, giving subtly different movement for gentle versus intense passages.

--- a/generator/bass_generator.py
+++ b/generator/bass_generator.py
@@ -158,6 +158,15 @@ class BassGenerator(BasePartGenerator):
         main_cfg=None,
         **kwargs,
     ):
+        """Create a bass part generator.
+
+        Parameters
+        ----------
+        mirror_melody : bool, optional
+            If ``True``, invert the melody line around the tonic when generating
+            bass notes. Default is ``False``.  Set this in ``main_cfg.yml`` under
+            ``part_defaults.bass`` to apply globally.
+        """
         super().__init__(
             global_settings=global_settings,
             default_instrument=default_instrument,
@@ -168,10 +177,10 @@ class BassGenerator(BasePartGenerator):
             **kwargs,
         )
         self.cfg: dict = kwargs.copy()
-        self.mirror_melody = mirror_melody
         self.logger = logging.getLogger("modular_composer.bass_generator")
         self.part_parameters = kwargs.get("part_parameters", {})
         self.main_cfg = main_cfg
+        # Whether to mirror the main melody when generating the bass line
         self.mirror_melody = mirror_melody
         # ここで global_ts_str をセット
         self.global_ts_str = global_time_signature


### PR DESCRIPTION
## Summary
- document how to enable bass mirror melody feature in `arrangement_features.md`
- add explanatory docstring for `BassGenerator` constructor and clean duplicate assignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b025d9638832881c071d030091a5a