### PR TITLE
Update tests to new rhythm fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from pathlib import Path
+from utilities.rhythm_library_loader import load_rhythm_library
+
+@pytest.fixture(scope="session")
+def rhythm_library():
+    path = Path(__file__).resolve().parents[1] / "data" / "rhythm_library.yml"
+    return load_rhythm_library(path)

--- a/tests/test_drum_generator.py
+++ b/tests/test_drum_generator.py
@@ -1,32 +1,14 @@
-import os
-import sys
 import json
 import tempfile
 from pathlib import Path
+
 from music21 import note, stream
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-import importlib.util
-import types
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-pkg = types.ModuleType("generator")
-pkg.__path__ = [str(ROOT / "generator")]
-sys.modules.setdefault("generator", pkg)
-
-spec = importlib.util.spec_from_file_location(
-    "generator.drum_generator",
-    ROOT / "generator" / "drum_generator.py",
-    submodule_search_locations=[str(ROOT / "generator")],
+from generator.drum_generator import (
+    DrumGenerator,
+    RESOLUTION,
+    HAT_SUPPRESSION_THRESHOLD,
 )
-_mod = importlib.util.module_from_spec(spec)
-sys.modules["generator.drum_generator"] = _mod
-spec.loader.exec_module(_mod)
-DrumGenerator = _mod.DrumGenerator
-RESOLUTION = _mod.RESOLUTION
-HAT_SUPPRESSION_THRESHOLD = _mod.HAT_SUPPRESSION_THRESHOLD
 
 
 class SimpleDrumGenerator(DrumGenerator):
@@ -51,14 +33,18 @@ class SimpleDrumGenerator(DrumGenerator):
         return part
 
 
-def test_hat_suppressed_by_heatmap(tmp_path: Path):
+def test_hat_suppressed_by_heatmap(tmp_path: Path, rhythm_library):
     heatmap = [{"grid_index": i, "count": (10 if i == 4 else 1)} for i in range(RESOLUTION)]
     heatmap_path = tmp_path / "heatmap.json"
     with open(heatmap_path, "w") as f:
         json.dump(heatmap, f)
 
     cfg = {"vocal_midi_path_for_drums": "", "heatmap_json_path_for_drums": str(heatmap_path), "rng_seed": 0}
-    drum = SimpleDrumGenerator(main_cfg=cfg, part_name="drums")
+    drum = SimpleDrumGenerator(
+        main_cfg=cfg,
+        part_name="drums",
+        part_parameters=rhythm_library.drum_patterns or {},
+    )
 
     section = {"absolute_offset": 0.0, "length_in_measures": 1}
     part = drum.compose(section_data=section)

--- a/tests/test_groove_sync.py
+++ b/tests/test_groove_sync.py
@@ -1,31 +1,15 @@
-import os
-import sys
 import json
-import importlib.util
 from pathlib import Path
+
 from music21 import note, stream
 
-# Set up module import similar to other tests
-ROOT = Path(__file__).resolve().parents[1]
-pkg = sys.modules.setdefault("generator", type(sys)("generator"))
-pkg.__path__ = [str(ROOT / "generator")]
-
-spec = importlib.util.spec_from_file_location(
-    "generator.drum_generator",
-    ROOT / "generator" / "drum_generator.py",
-    submodule_search_locations=[str(ROOT / "generator")],
-)
-_mod = importlib.util.module_from_spec(spec)
-sys.modules["generator.drum_generator"] = _mod
-spec.loader.exec_module(_mod)
-DrumGenerator = _mod.DrumGenerator
-RESOLUTION = _mod.RESOLUTION
+from generator.drum_generator import DrumGenerator, RESOLUTION
 
 class GrooveTestDrum(DrumGenerator):
     def _resolve_style_key(self, musical_intent, overrides, section_data=None):
         return "simple"
 
-def test_groove_offsets(tmp_path: Path):
+def test_groove_offsets(tmp_path: Path, rhythm_library):
     # groove profile with simple offsets
     gp = {"0": 0.1, "4": -0.05}
     gp_path = tmp_path / "gp.json"
@@ -43,16 +27,19 @@ def test_groove_offsets(tmp_path: Path):
         "vocal_midi_path_for_drums": "",
         "heatmap_json_path_for_drums": str(heatmap_path),
     }
-    pattern_lib = {
-        "simple": {
-            "pattern": [
-                {"offset": 0.0, "duration": 0.25, "instrument": "snare"},
-                {"offset": 0.25, "duration": 0.25, "instrument": "snare"},
-            ],
-            "length_beats": 4.0,
-        }
+    pattern_lib = rhythm_library.drum_patterns or {}
+    pattern_lib["simple"] = {
+        "pattern": [
+            {"offset": 0.0, "duration": 0.25, "instrument": "snare"},
+            {"offset": 0.25, "duration": 0.25, "instrument": "snare"},
+        ],
+        "length_beats": 4.0,
     }
-    drum = GrooveTestDrum(main_cfg=cfg, part_name="drums", part_parameters=pattern_lib)
+    drum = GrooveTestDrum(
+        main_cfg=cfg,
+        part_name="drums",
+        part_parameters=pattern_lib,
+    )
 
     section = {"absolute_offset": 0.0, "q_length": 4.0, "musical_intent": {}, "part_params": {}}
     part = drum.compose(section_data=section)

--- a/tests/test_onset_heatmap.py
+++ b/tests/test_onset_heatmap.py
@@ -1,10 +1,5 @@
-import os
-import sys
 import tempfile
 import pretty_midi
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from utilities.onset_heatmap import build_heatmap
 
 


### PR DESCRIPTION
## Summary
- add shared fixture to load rhythm library
- use the fixture in drum tests and groove sync test
- remove old path hacks from tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b044266648328a7180cf969d70ff9