### PR TITLE
Refactor: Single-source ROLE_DISPATCH

### DIFF
--- a/utilities/generator_factory.py
+++ b/utilities/generator_factory.py
@@ -25,11 +25,10 @@ class GenFactory:
         """
         global_settings = main_cfg.get("global_settings", {})
         gens = {}
-        role_dispatch = main_cfg.get("role_dispatch", ROLE_DISPATCH)
         for part_name, part_cfg in main_cfg["part_defaults"].items():
             role = part_cfg.get("role", part_name)  # role が無ければ楽器名と同じ
             try:
-                GenCls = role_dispatch[role]
+                GenCls = ROLE_DISPATCH[role]
             except KeyError as e:
                 raise KeyError(f"Unknown role '{role}' for part '{part_name}'") from e
             cleaned_part_cfg = dict(part_cfg)


### PR DESCRIPTION
## Summary
- centralize role dispatch lookup in `GenFactory`
- keep explicit ROLE_DISPATCH mapping in one place

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1d7b96e88328b9c895a196e2e514