### PR TITLE
Add chord parser with tension support

### DIFF
--- a/tests/test_parse_chord_symbol.py
+++ b/tests/test_parse_chord_symbol.py
@@ -1,0 +1,16 @@
+import pytest
+from generator.chord_voicer import parse_chord_symbol
+
+@pytest.mark.parametrize(
+    "symbol,expected",
+    [
+        ("Cadd9", ["C", "E", "G", "D"]),
+        ("Dsus2", ["D", "E", "A"]),
+        ("Am7", ["A", "C", "E", "G"]),
+        ("F6", ["F", "A", "C", "D"]),
+    ],
+)
+def test_parse_chord_symbol(symbol, expected):
+    notes = parse_chord_symbol(symbol)
+    names = [p.name for p in notes]
+    assert names == expected


### PR DESCRIPTION
## Summary
- extend `chord_voicer` with `parse_chord_symbol` capable of recognising add9, sus2, m7 and 6
- implement regex-based parsing and interval mapping
- add tests for new parser handling Cadd9, Dsus2, Am7 and F6

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c00fecf248328973f03dd363311d3