### PR TITLE
Remove duplicate drum render method

### DIFF
--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -590,45 +590,6 @@ class DrumGenerator(BasePartGenerator):
         self.pattern_lib_cache[style_key] = copy.deepcopy(pattern_def)
         return pattern_def
 
-    def _render_part(
-        self,
-        section_data: Dict[str, Any],
-        next_section_data: Optional[Dict[str, Any]] = None,
-    ) -> stream.Part:
-        part = stream.Part(id=self.part_name)
-        part.insert(0, self.default_instrument)
-
-        # (前回 drum_generator.py の _render_part に実装したロジックをここに記述)
-        # ... ヒートマップとパターンに基づいてドラムヒットを生成 ...
-        log_prefix = (
-            f"DrumGen._render_part (Sec: {section_data.get('section_name', 'Unk')})"
-        )
-
-        # パラメータ取得
-        drum_params = section_data.get("part_params", {}).get(self.part_name, {})
-
-        # パターン選択
-        musical_intent = section_data.get("musical_intent", {})
-        # ... (emotion/intensity からパターンキーを選択するロジック) ...
-
-        # リズム生成
-        start_offset = section_data.get("absolute_offset", 0.0)
-        duration_ql = section_data.get("q_length", 4.0)
-        end_offset = start_offset + duration_ql
-
-        # 仮のシンプルなロジック
-        t = 0.0
-        while t < duration_ql:
-            kick = note.Note("C2")  # Kick
-            kick.duration.quarterLength = 0.5
-            part.insert(t, kick)
-            t += 1.0
-
-        logger.info(
-            f"{log_prefix}: Finished rendering. Part has {len(part.flatten().notes)} notes."
-        )
-        return part
-
     def compose(
         self,
         *,

--- a/tests/test_drum_no_duplicate.py
+++ b/tests/test_drum_no_duplicate.py
@@ -1,0 +1,6 @@
+import generator.drum_generator as drum_generator
+
+def test_no_kick_only_impl():
+    count = drum_generator.DrumGenerator._render_part.__code__.co_consts.count("kick")
+    assert count < 3
+


### PR DESCRIPTION
## Summary
- clean up `drum_generator` by removing a simple `_render_part` implementation
- add a regression test ensuring no leftover "kick-only" logic exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c67bcb5f88328b28f80be8e269f4d