### PR TITLE
Load drum patterns from rhythm library

### DIFF
--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -497,16 +497,11 @@ class DrumGenerator(BasePartGenerator):
         if hasattr(self.instrument, "midiChannel"):
             self.instrument.midiChannel = 9
 
-        # drum_patterns.yml をロードして raw_pattern_lib にマージ
-        lib_from_files = self._load_pattern_lib(
-            self.main_cfg["paths"]["drum_pattern_files"]
+        # rhythm_library.yml 内の drum_patterns をロードして raw_pattern_lib にマージ
+        lib = yaml.safe_load(
+            open(self.main_cfg["paths"]["rhythm_library_path"], "r", encoding="utf-8")
         )
-        if lib_from_files:
-            self.raw_pattern_lib.update(lib_from_files)
-            logger.info(
-                "DrumGen __init__: loaded %d patterns from data/drum_patterns.yml",
-                len(lib_from_files),
-            )
+        self.raw_pattern_lib.update(lib.get("drum_patterns", {}))
 
         # 最終的なパターン辞書を part_parameters に適用
         self.part_parameters = self.raw_pattern_lib

--- a/tests/test_drum_generator.py
+++ b/tests/test_drum_generator.py
@@ -43,7 +43,7 @@ def test_hat_suppressed_by_heatmap(tmp_path: Path, rhythm_library):
         "vocal_midi_path_for_drums": "",
         "heatmap_json_path_for_drums": str(heatmap_path),
         "rng_seed": 0,
-        "paths": {"drum_pattern_files": ["data/drum_patterns.yml"]},
+        "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
     }
     drum = SimpleDrumGenerator(
         main_cfg=cfg,

--- a/tests/test_drum_pattern_resolve.py
+++ b/tests/test_drum_pattern_resolve.py
@@ -12,7 +12,11 @@ def test_relative_path_resolved(monkeypatch, tmp_path):
     cfg = {
         "vocal_midi_path_for_drums": "",
         "heatmap_json_path_for_drums": str(Path("data/heatmap.json").resolve()),
-        "paths": {"drum_pattern_files": []},
+        "paths": {
+            "rhythm_library_path": str(
+                Path(__file__).resolve().parents[1] / "data" / "rhythm_library.yml"
+            )
+        },
     }
     drum = DummyDrum(
         main_cfg=cfg,

--- a/tests/test_groove_sync.py
+++ b/tests/test_groove_sync.py
@@ -26,7 +26,7 @@ def test_groove_offsets(tmp_path: Path, rhythm_library):
         "global_settings": {"groove_profile_path": str(gp_path), "groove_strength": 1.0},
         "vocal_midi_path_for_drums": "",
         "heatmap_json_path_for_drums": str(heatmap_path),
-        "paths": {"drum_pattern_files": ["data/drum_patterns.yml"]},
+        "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
     }
     pattern_lib = rhythm_library.drum_patterns or {}
     pattern_lib["simple"] = {

--- a/tests/test_kick_interface.py
+++ b/tests/test_kick_interface.py
@@ -22,7 +22,7 @@ def test_drum_kick_offsets(tmp_path):
     cfg = {
         "vocal_midi_path_for_drums": "",
         "heatmap_json_path_for_drums": str(heatmap_path),
-        "paths": {"drum_pattern_files": []},
+        "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
     }
     drum = EightKickDrum(
         main_cfg=cfg,
@@ -42,7 +42,7 @@ def test_compose_shared_kicks(tmp_path):
         "global_settings": {"time_signature": "4/4", "tempo_bpm": 120},
         "sections_to_generate": ["A"],
         "part_defaults": {"drums": {"role": "drums"}, "bass": {"role": "bass"}},
-        "paths": {"drum_pattern_files": []},
+        "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
     }
     chordmap = {
         "sections": {


### PR DESCRIPTION
## Summary
- update `drum_generator` to read drum patterns from `rhythm_library.yml`
- adjust tests to provide `rhythm_library_path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3fff95e8832886acf29af586e59a