### PR TITLE
Add hat_closed drum label support

### DIFF
--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -123,6 +123,7 @@ GM_DRUM_MAP: Dict[str, int] = {
 }
 DRUM_ALIAS: Dict[str, str] = {
     "hh": "closed_hi_hat",
+    "hat_closed": "closed_hi_hat",
     "ohh": "open_hi_hat",
     "shaker_soft": "shaker",
     "chimes": "triangle",
@@ -134,6 +135,7 @@ GHOST_ALIAS: Dict[str, str] = {"ghost_snare": "snare", "gs": "snare"}
 # Fallback mapping for drum names missing from GM_DRUM_MAP
 MISSING_DRUM_MAP_FALLBACK: Dict[str, str] = {
     "hh": "chh",
+    "hat_closed": "chh",
     "ghost": "chh",
     "shaker_soft": "shaker",
     "chimes": "triangle",

--- a/tests/test_drum_alias.py
+++ b/tests/test_drum_alias.py
@@ -18,6 +18,7 @@ def test_drum_alias_mapping(tmp_path, rhythm_library):
             "pattern": [
                 {"instrument": "hh", "offset": 0.0, "duration": 0.25},
                 {"instrument": "shaker_soft", "offset": 1.0, "duration": 0.25},
+                {"instrument": "hat_closed", "offset": 1.5, "duration": 0.25},
             ],
             "length_beats": 2.0,
         }
@@ -37,5 +38,5 @@ def test_drum_alias_mapping(tmp_path, rhythm_library):
     section = {"absolute_offset": 0.0, "q_length": 2.0, "musical_intent": {}, "part_params": {}}
     part = drum.compose(section_data=section)
     mids = [n.pitch.midi for n in part.flatten().notes]
-    assert GM_DRUM_MAP["closed_hi_hat"] in mids
+    assert mids.count(GM_DRUM_MAP["closed_hi_hat"]) == 2
     assert GM_DRUM_MAP["shaker"] in mids

--- a/utilities/drum_map_registry.py
+++ b/utilities/drum_map_registry.py
@@ -4,6 +4,7 @@
 GM_DRUM_MAP = {
     "chh": ("closed_hi_hat", 42),
     "hh": ("closed_hi_hat", 42),
+    "hat_closed": ("closed_hi_hat", 42),
     "ohh": ("open_hi_hat", 46),
     "kick": ("acoustic_bass_drum", 36),
     "snare": ("acoustic_snare", 38),
@@ -25,6 +26,7 @@ GM_DRUM_MAP = {
 UJAM_LEGEND_MAP = {
     "chh": ("closed_hi_hat", 42),
     "hh": ("closed_hi_hat", 42),
+    "hat_closed": ("closed_hi_hat", 42),
     "ohh": ("open_hi_hat", 46),
     "kick": ("kick", 36),
     "snare": ("snare", 38),


### PR DESCRIPTION
## Summary
- support `hat_closed` in both drum maps
- map `hat_closed` as an alias and fallback
- exercise alias in drum alias tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eea6a4e68832888a9377420b473bc