### PR TITLE
Fix drum generator vocal MIDI path

### DIFF
--- a/config/main_cfg.yml
+++ b/config/main_cfg.yml
@@ -41,7 +41,7 @@ paths:
   vocal_heatmap_path: "../data/heatmap.json"
   vocal_note_data_path: "../data/vocal_note_data_ore.json"
   output_dir: "../midi_output"
-vocal_midi_path_for_drums: "../data/vocal.mid"
+  vocal_midi_path_for_drums: "../data/vocal.mid"
 
 # ---------------- 3. Part Defaults ------------------
 part_defaults:

--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -292,10 +292,12 @@ class DrumGenerator(BasePartGenerator):
         # 必須のデフォルトパターンが不足している場合に補充
         self._add_internal_default_patterns()
 
-        # Use path settings from main_cfg, falling back to general paths
-        self.vocal_midi_path = self.main_cfg.get(
-            "vocal_midi_path_for_drums"
-        ) or self.main_cfg.get("paths", {}).get("vocal_note_data_path")
+        # Use path settings from main_cfg, preferring an explicit MIDI file path
+        self.vocal_midi_path = (
+            self.main_cfg.get("paths", {}).get("vocal_midi_path_for_drums")
+            or self.main_cfg.get("vocal_midi_path_for_drums")
+            or self.main_cfg.get("paths", {}).get("vocal_note_data_path")
+        )
         self.vocal_end_times: List[float] = self._load_vocal_end_times(
             self.vocal_midi_path
         )


### PR DESCRIPTION
## Summary
- move `vocal_midi_path_for_drums` inside the `paths` section
- prefer this key when loading the vocal MIDI in `DrumGenerator`

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685184c63c448328b7c89b4e517be183