### PR TITLE
Ensure gm drum map default

### DIFF
--- a/modular_composer.py
+++ b/modular_composer.py
@@ -297,8 +297,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
     p.add_argument(
         "--drum-map",
+        default="gm",
         choices=DRUM_MAPS.keys(),
-        help="使用するドラムマッピングを選択",
+        help="使用するドラムマッピングを選択 (default: gm)",
     )
     return p
 
@@ -328,7 +329,7 @@ def main_cli() -> None:
     logger.info("使用 rhythm_library_path = %s", paths["rhythm_library_path"])
 
     drum_map_name = args.drum_map or main_cfg.get(
-        "global_settings", {}).get("drum_map")
+        "global_settings", {}).get("drum_map") or "gm"
     main_cfg.setdefault("global_settings", {})["drum_map"] = drum_map_name
 
     # 3. ファイル読み込み

--- a/tests/test_default_drum_map.py
+++ b/tests/test_default_drum_map.py
@@ -1,0 +1,22 @@
+import pytest
+from utilities.generator_factory import GenFactory
+
+def test_build_from_config_default_drum_map(rhythm_library):
+    main_cfg = {
+        "global_settings": {
+            "time_signature": "4/4",
+            "tempo_bpm": 120,
+            "key_tonic": "C",
+            "key_mode": "major",
+        },
+        "sections_to_generate": ["A"],
+        "part_defaults": {"drums": {"role": "drums"}},
+        "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
+    }
+
+    gens = GenFactory.build_from_config(main_cfg, rhythm_library)
+    drum_gen = gens["drums"]
+
+    assert drum_gen.drum_map_name == "gm"
+    assert drum_gen.drum_map.get("kick")[1] == 36
+


### PR DESCRIPTION
## Summary
- add `default="gm"` for drum-map argument
- default to General MIDI mapping when CLI or config omit it
- test that `GenFactory.build_from_config` defaults to GM

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bbae144483289e32f4dde7915242