### PR TITLE
Implement push-pull and swing timing merge

### DIFF
--- a/tests/test_push_pull_swing.py
+++ b/tests/test_push_pull_swing.py
@@ -1,0 +1,49 @@
+from generator.drum_generator import _combine_timing
+
+
+def _eval(rel, pp, swing, bpm=120):
+    beat_len = 1.0
+    return _combine_timing(
+        rel,
+        beat_len,
+        swing_ratio=swing,
+        swing_type="eighth",
+        push_pull_curve=pp,
+        tempo_bpm=bpm,
+    )
+
+
+def test_push_pull_only():
+    pp = [20, -20, 0, 0]
+    assert _eval(0.0, pp, 0.5) > 0.0
+    assert _eval(1.0, pp, 0.5) < 1.0
+
+
+def test_push_pull_and_swing():
+    pp = [0, 0, 0, 0]
+    straight = _eval(0.5, pp, 0.5)
+    swung = _eval(0.5, pp, 0.66)
+    assert swung > straight
+
+
+def test_sixteenth_swing():
+    pp = [0, 0, 0, 0]
+    beat_len = 1.0
+    base = _combine_timing(
+        0.25,
+        beat_len,
+        swing_ratio=0.5,
+        swing_type="sixteenth",
+        push_pull_curve=pp,
+        tempo_bpm=120,
+    )
+    swung = _combine_timing(
+        0.25,
+        beat_len,
+        swing_ratio=0.66,
+        swing_type="sixteenth",
+        push_pull_curve=pp,
+        tempo_bpm=120,
+    )
+    assert swung > base
+


### PR DESCRIPTION
## Summary
- add `_combine_timing` helper that merges push‑pull and swing timing adjustments
- remove old `_swing` method and update pattern rendering
- initialise `current_push_pull_curve`
- test push‑pull and swing interaction, including sixteenth swing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854117a97a88328ba4bb9eee24996c0