### PR TITLE
Add regression tests for drum articulations

### DIFF
--- a/tests/test_drag_ruff.py
+++ b/tests/test_drag_ruff.py
@@ -13,6 +13,7 @@ def _minimal_cfg(tmp_path: Path):
         "vocal_midi_path_for_drums": "",
         "heatmap_json_path_for_drums": str(hp),
         "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
+        "rng_seed": 0,
     }
 
 
@@ -47,8 +48,11 @@ def test_drag_and_ruff(tmp_path: Path):
 
     for notes in (drag_notes, ruff_notes):
         main_offset = notes[-1].offset
+        main_vel = notes[-1].volume.velocity
         for n in notes:
             assert int(n.pitch.midi) == GM_DRUM_MAP["snare"][1]
         for g in notes[:-1]:
             dt = (main_offset - g.offset) * 60 / drum.global_tempo
             assert 0 < dt <= 0.03
+            ratio = g.volume.velocity / main_vel
+            assert 0.3 <= ratio <= 0.6

--- a/tests/test_drum_articulations.py
+++ b/tests/test_drum_articulations.py
@@ -46,6 +46,31 @@ def test_hihat_articulations(tmp_path: Path):
     assert pitches == expected
 
 
+def test_hihat_edge_pedal(tmp_path: Path):
+    cfg = _cfg(tmp_path)
+    drum = DrumGenerator(main_cfg=cfg, part_name="drums", part_parameters={})
+    part = stream.Part(id="drums")
+    events = [
+        {"instrument": "chh", "offset": 0.0, "velocity": 30},
+        {"instrument": "chh", "offset": 1.0, "velocity": 80, "pedal": True},
+    ]
+    drum._apply_pattern(
+        part,
+        events,
+        0.0,
+        2.0,
+        90,
+        "eighth",
+        0.5,
+        drum.global_ts,
+        {},
+    )
+    notes = sorted(part.flatten().notes, key=lambda n: n.offset)
+    assert len(notes) == 2
+    assert notes[0].pitch.midi == GM_DRUM_MAP["hh_edge"][1]
+    assert notes[1].pitch.midi == GM_DRUM_MAP["hh_pedal"][1]
+
+
 def test_velocity_random_walk(tmp_path: Path):
     cfg = _cfg(tmp_path)
     cfg["random_walk_step"] = 4


### PR DESCRIPTION
## Summary
- add hi-hat edge and pedal test
- extend drag/ruff test with velocity checks and deterministic seed

## Testing
- `pytest tests/test_drum_articulations.py::test_hihat_edge_pedal -q`
- `pytest tests/test_drag_ruff.py::test_drag_and_ruff -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c92e90788328b4dffd1c7c49ac45