### PR TITLE
Add tempo curve drumgen notebook

### DIFF
--- a/examples/drumgen_tempo_curve.ipynb
+++ b/examples/drumgen_tempo_curve.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "99191cdb",
+   "metadata": {},
+   "source": [
+    "# ドラムジェネレータ: テンポ曲線の適用\n",
+    "\n",
+    "このチュートリアルでは、テンポ曲線(JSON)を読み込み、DrumGenerator に適用して MIDI を生成・試聴します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30c3cf36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from utilities.tempo_utils import TempoMap, load_tempo_map\n",
+    "from generator.drum_generator import DrumGenerator\n",
+    "from music21 import meter, stream\n",
+    "import json\n",
+    "from IPython.display import Audio, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad627d07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tempo_map = load_tempo_map('examples/tempo_curve.json')\n",
+    "print('Loaded events:', tempo_map.events)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2216adc0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# テンポ曲線の可視化 (beat vs BPM)\n",
+    "import matplotlib.pyplot as plt\n",
+    "beats = [e['beat'] for e in tempo_map.events]\n",
+    "bpms = [e['bpm'] for e in tempo_map.events]\n",
+    "plt.plot(beats, bpms, marker='o')\n",
+    "plt.xlabel('Beat')\n",
+    "plt.ylabel('BPM')\n",
+    "plt.title('Tempo Curve')\n",
+    "plt.grid(True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d83b0c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dg = DrumGenerator(main_cfg={'tempo_map_path': 'examples/tempo_curve.json'}, global_settings={'use_velocity_ema': False})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1adb432e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "part = dg.compose(section_data={\n",
+    "    'q_length': 4.0,\n",
+    "    'chord_symbol_for_voicing': 'Rest',\n",
+    "    'part_params': {},\n",
+    "    'musical_intent': {'emotion': 'default', 'intensity': 'medium'},\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73f0fe2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "midi_path = 'examples/drum_tempo_curve.mid'\n",
+    "part.write('midi', fp=midi_path)\n",
+    "print('Wrote MIDI to', midi_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a89d85f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(Audio(midi_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "283eb062",
+   "metadata": {},
+   "source": [
+    "以上でテンポ曲線を用いたドラムパートの生成と試聴が完了しました。\n",
+    "\n",
+    "より発展的な使い方や他の例については、リポジトリ内のノートブックも参照してください。"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/tempo_curve.json
+++ b/examples/tempo_curve.json
@@ -1,0 +1,5 @@
+[
+  {"beat": 0, "bpm": 120, "curve": "linear"},
+  {"beat": 32, "bpm": 108, "curve": "linear"},
+  {"beat": 64, "bpm": 128}
+]


### PR DESCRIPTION
## Summary
- provide `examples/tempo_curve.json` for use in demos
- add `examples/drumgen_tempo_curve.ipynb` showing how to load a tempo curve and generate drum MIDI with DrumGenerator

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b795863ac8328b6b199141d835753