### PR TITLE
Add new drum patterns and cowbell mapping

### DIFF
--- a/data/drum_patterns.yml
+++ b/data/drum_patterns.yml
@@ -1361,6 +1361,129 @@ drum_patterns:
       - {instrument: hh, offset: 3.0, duration: 1.0}
       - {instrument: hh, offset: 3.5, duration: 1.0}
 
+  rock_drive_loop:
+    description: "Driving rock loop"
+    time_signature: "4/4"
+    pattern_type: "fixed_pattern"
+    length_beats: 4.0
+    drum_base_velocity: 90
+    tags: ["rock", "drive", "medium"]
+    options:
+      velocity_curve: crescendo
+    pattern:
+      - {instrument: kick, offset: 0.0, duration: 1.0}
+      - {instrument: snare, offset: 1.0, duration: 1.0}
+      - {instrument: kick, offset: 2.0, duration: 1.0}
+      - {instrument: snare, offset: 3.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 0.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 0.5, duration: 1.0}
+      - {instrument: hat_closed, offset: 1.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 1.5, duration: 1.0}
+      - {instrument: hat_closed, offset: 2.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 2.5, duration: 1.0}
+      - {instrument: hat_closed, offset: 3.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 3.5, duration: 1.0}
+
+  brush_ballad_loop:
+    description: "Gentle brush ballad"
+    time_signature: "4/4"
+    pattern_type: "fixed_pattern"
+    length_beats: 4.0
+    drum_base_velocity: 70
+    tags: ["ballad", "brush", "low"]
+    options:
+      velocity_curve: flat
+    pattern:
+      - {instrument: kick, offset: 0.0, duration: 1.0}
+      - {instrument: snare_brush, offset: 2.0, duration: 1.0}
+      - {instrument: hh_pedal, offset: 0.0, duration: 1.0}
+      - {instrument: hh_pedal, offset: 1.0, duration: 1.0}
+      - {instrument: hh_pedal, offset: 2.0, duration: 1.0}
+      - {instrument: hh_pedal, offset: 3.0, duration: 1.0}
+
+  funk_shuffle:
+    description: "Funky shuffle"
+    time_signature: "4/4"
+    pattern_type: "fixed_pattern"
+    length_beats: 4.0
+    drum_base_velocity: 85
+    tags: ["funk", "shuffle", "high"]
+    options:
+      velocity_curve: swell
+    pattern:
+      - {instrument: kick, offset: 0.0, duration: 1.0}
+      - {instrument: snare, offset: 0.75, duration: 1.0}
+      - {instrument: kick, offset: 1.5, duration: 1.0}
+      - {instrument: snare, offset: 2.25, duration: 1.0}
+      - {instrument: kick, offset: 3.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 0.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 0.75, duration: 1.0}
+      - {instrument: hat_closed, offset: 1.5, duration: 1.0}
+      - {instrument: hat_closed, offset: 2.25, duration: 1.0}
+      - {instrument: hat_closed, offset: 3.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 3.75, duration: 1.0}
+
+  latin_groove:
+    description: "Latin groove with cowbell"
+    time_signature: "4/4"
+    pattern_type: "fixed_pattern"
+    length_beats: 4.0
+    drum_base_velocity: 80
+    tags: ["latin", "groove", "medium"]
+    options:
+      velocity_curve: decrescendo
+    pattern:
+      - {instrument: kick, offset: 0.0, duration: 1.0}
+      - {instrument: snare, offset: 1.0, duration: 1.0}
+      - {instrument: kick, offset: 2.0, duration: 1.0}
+      - {instrument: snare, offset: 3.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 0.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 0.5, duration: 1.0}
+      - {instrument: hat_closed, offset: 1.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 1.5, duration: 1.0}
+      - {instrument: hat_closed, offset: 2.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 2.5, duration: 1.0}
+      - {instrument: hat_closed, offset: 3.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 3.5, duration: 1.0}
+      - {instrument: cowbell, offset: 1.5, duration: 1.0}
+      - {instrument: cowbell, offset: 3.5, duration: 1.0}
+
+  ballad_backbeat:
+    description: "Sparse ballad backbeat"
+    time_signature: "4/4"
+    pattern_type: "fixed_pattern"
+    length_beats: 4.0
+    drum_base_velocity: 75
+    tags: ["ballad", "backbeat", "low"]
+    options:
+      velocity_curve: flat
+    pattern:
+      - {instrument: kick, offset: 0.0, duration: 1.0}
+      - {instrument: snare, offset: 2.0, duration: 1.0}
+
+  swing_medium:
+    description: "Medium swing groove"
+    time_signature: "4/4"
+    pattern_type: "fixed_pattern"
+    length_beats: 4.0
+    drum_base_velocity: 88
+    tags: ["swing", "medium", "groove"]
+    options:
+      velocity_curve: crescendo
+    pattern:
+      - {instrument: kick, offset: 0.0, duration: 1.0}
+      - {instrument: snare, offset: 0.75, duration: 1.0}
+      - {instrument: kick, offset: 1.5, duration: 1.0}
+      - {instrument: snare, offset: 2.25, duration: 1.0}
+      - {instrument: kick, offset: 3.0, duration: 1.0}
+      - {instrument: snare, offset: 3.75, duration: 1.0}
+      - {instrument: hat_closed, offset: 0.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 0.75, duration: 1.0}
+      - {instrument: hat_closed, offset: 1.5, duration: 1.0}
+      - {instrument: hat_closed, offset: 2.25, duration: 1.0}
+      - {instrument: hat_closed, offset: 3.0, duration: 1.0}
+      - {instrument: hat_closed, offset: 3.75, duration: 1.0}
+
 flam_test:
   pattern_type: simple
   pattern:

--- a/utilities/drum_map_registry.py
+++ b/utilities/drum_map_registry.py
@@ -43,6 +43,7 @@ GM_DRUM_MAP: Dict[str, Tuple[str, int]] = {
     "ride_cymbal_swell": ("ride_cymbal_1", 51),
     "ride_bell": ("ride_cymbal_bell", 53),
     "splash": ("splash_cymbal", 55),
+    "cowbell": ("cowbell", 56),
     "crash_choke": ("crash_cymbal_1", 49),
     # FX
     "chimes": ("triangle", 81),
@@ -73,6 +74,7 @@ _LEGEND_BASE = {
         "ride_bell",
         "splash",
         "crash_choke",
+        "cowbell",
     }
 }
 UJAM_LEGEND_MAP: Dict[str, Tuple[str, int]] = {
@@ -122,6 +124,7 @@ MISSING_DRUM_MAP_FALLBACK = {
     "chimes": "chimes",
     "ride_cymbal_swell": "ride_cymbal_swell",
     "crash_cymbal_soft_swell": "crash_cymbal_soft_swell",
+    "cowbell": "cowbell",
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expand `drum_patterns.yml` with six new patterns: rock_drive_loop, brush_ballad_loop, funk_shuffle, latin_groove, ballad_backbeat, swing_medium
- support `cowbell` instrument via `drum_map_registry`

## Testing
- `pip install -r requirements.txt`
- `pip install setuptools`
- `pip install hypothesis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7c98f0448328b8be1f038833a854