### PR TITLE
Implement consonant sync mode toggle

### DIFF
--- a/config/main_cfg.yml
+++ b/config/main_cfg.yml
@@ -35,7 +35,8 @@ global_settings:
   bass_range_hi: 64
   fill_emotion_threshold: 0.8
   fill_fade_beats: 2.0
-  use_consonant_sync: false
+  use_consonant_sync: true
+  consonant_sync_mode: bar  # 'bar' or 'note'
 
 # ------------------- 2. Paths -----------------------
 paths:

--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -43,7 +43,7 @@ from utilities.humanizer import apply_humanization_to_element
 from utilities.onset_heatmap import RESOLUTION, load_heatmap
 from utilities.safe_get import safe_get
 from utilities.tempo_utils import TempoMap, load_tempo_map
-from utilities.timing_utils import _combine_timing
+from utilities.timing_utils import _combine_timing, align_to_consonant
 from utilities.velocity_smoother import EMASmoother
 
 from .base_part_generator import BasePartGenerator
@@ -450,6 +450,9 @@ class DrumGenerator(BasePartGenerator):
             "sustain_threshold_ms": float(sync_cfg.get("sustain_threshold_ms", 120.0)),
         }
         self.use_consonant_sync = bool((global_settings or {}).get("use_consonant_sync", False))
+        self.consonant_sync_mode = str(
+            (global_settings or {}).get("consonant_sync_mode", "bar")
+        ).lower()
 
         peak_json_path = (
             self.main_cfg.get("paths", {}).get("vocal_peak_json_for_drums")
@@ -1244,7 +1247,11 @@ class DrumGenerator(BasePartGenerator):
                 resolution=self.groove_resolution,
             )
 
-        if self.use_consonant_sync and self.consonant_peaks:
+        if (
+            self.use_consonant_sync
+            and self.consonant_peaks
+            and self.consonant_sync_mode == "bar"
+        ):
             start_sec = self._convert_ticks_to_seconds(
                 int(bar_start_abs_offset * self.ppq)
             )
@@ -1376,6 +1383,19 @@ class DrumGenerator(BasePartGenerator):
                 max_dur = (0.3 * self.current_bpm) / 60.0
                 clipped_duration_ql = min(clipped_duration_ql, max_dur)
             final_insert_offset_in_score = bar_start_abs_offset + rel_offset_in_pattern
+            if (
+                self.use_consonant_sync
+                and inst_name in {"kick", "snare"}
+                and self.consonant_peaks
+                and self.consonant_sync_mode == "note"
+            ):
+                final_insert_offset_in_score = align_to_consonant(
+                    final_insert_offset_in_score,
+                    self.consonant_peaks,
+                    self.current_bpm,
+                    lag_ms=self.consonant_sync_cfg["lag_ms"],
+                )
+                final_insert_offset_in_score = max(0.0, final_insert_offset_in_score)
             bin_idx = (
                 int(final_insert_offset_in_score * self.heatmap_resolution)
                 % self.heatmap_resolution

--- a/modular_composer.py
+++ b/modular_composer.py
@@ -309,6 +309,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
         choices=DRUM_MAPS.keys(),
         help="使用するドラムマッピングを選択 (default: gm)",
     )
+    p.add_argument(
+        "--consonant-sync-mode",
+        choices=["bar", "note"],
+        help="Consonant sync granularity override",
+    )
     return p
 
 
@@ -322,6 +327,10 @@ def main_cli() -> None:
         main_cfg.setdefault("global_settings", {})["strict_drum_map"] = True
     if args.drum_map:
         main_cfg.setdefault("global_settings", {})["drum_map"] = args.drum_map
+    if args.consonant_sync_mode:
+        main_cfg.setdefault("global_settings", {})[
+            "consonant_sync_mode"
+        ] = args.consonant_sync_mode
     paths = main_cfg.setdefault("paths", {})
     for k, v in (
         ("chordmap_path", args.chordmap),

--- a/tests/test_consonant_sync.py
+++ b/tests/test_consonant_sync.py
@@ -1,0 +1,78 @@
+import pytest
+
+import json
+from pathlib import Path
+from music21 import stream, meter
+from generator.drum_generator import DrumGenerator, RESOLUTION
+from utilities.timing_utils import align_to_consonant
+
+
+def test_aligns_when_peak_nearby() -> None:
+    off = align_to_consonant(1.0, [0.48], bpm=120, lag_ms=10.0)
+    assert off == pytest.approx(0.94, abs=1e-6)
+
+
+def test_no_alignment_outside_window() -> None:
+    off = align_to_consonant(0.0, [0.3], bpm=120, lag_ms=10.0)
+    assert off == pytest.approx(0.0, abs=1e-6)
+
+
+def test_far_peak_no_shift() -> None:
+    off = align_to_consonant(0.0, [1.6], bpm=120, lag_ms=10.0)
+    assert off == pytest.approx(0.0, abs=1e-6)
+
+
+def _cfg(tmp_path: Path, mode: str) -> dict:
+    heatmap = [{"grid_index": i, "count": 0} for i in range(RESOLUTION)]
+    hp = tmp_path / "heatmap.json"
+    with open(hp, "w") as f:
+        json.dump(heatmap, f)
+    return {
+        "vocal_midi_path_for_drums": "",
+        "heatmap_json_path_for_drums": str(hp),
+        "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
+        "global_settings": {
+            "use_consonant_sync": True,
+            "consonant_sync_mode": mode,
+            "tempo_bpm": 120,
+        },
+        "consonant_sync": {"lag_ms": 10.0},
+    }
+
+
+def _apply_single_kick(drum: DrumGenerator) -> list[float]:
+    part = stream.Part(id="drums")
+    events = [{"instrument": "kick", "offset": 1.0}]
+    drum._apply_pattern(
+        part,
+        events,
+        0.0,
+        4.0,
+        100,
+        "eighth",
+        0.5,
+        meter.TimeSignature("4/4"),
+        {},
+    )
+    return [float(n.offset) for n in part.flatten().notes]
+
+
+@pytest.mark.parametrize("mode", ["note", "bar"])
+def test_sync_modes(tmp_path: Path, mode: str) -> None:
+    cfg = _cfg(tmp_path, mode)
+    drum = DrumGenerator(
+        main_cfg=cfg,
+        global_settings=cfg["global_settings"],
+        part_name="drums",
+        part_parameters={},
+    )
+    drum.consonant_peaks = [0.48]
+    offsets = _apply_single_kick(drum)
+    if mode == "note":
+        assert offsets == pytest.approx([0.94], abs=1e-6)
+    else:
+        assert len(offsets) == 3
+        assert offsets[0] == pytest.approx(1.0, abs=1e-6)
+        assert offsets[1] == pytest.approx(1.0208, abs=1e-3)
+        assert offsets[2] == pytest.approx(1.2708, abs=1e-3)
+


### PR DESCRIPTION
## Summary
- add `consonant_sync_mode` global setting
- apply bar vs note peak alignment accordingly
- allow CLI override for consonant sync mode
- test both sync modes

## Testing
- `mypy --strict utilities/timing_utils.py generator/drum_generator.py tests/test_consonant_sync.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2cf137748328b4a2207c20b52f8e