### PR TITLE
Document consonant sync modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,24 @@ Use the JSON with the sampler to synchronise drums with consonants:
 modcompose sample model.pkl --peaks peaks.json --lag 10
 ```
 
+`global_settings.use_consonant_sync` enables this alignment. Set
+`consonant_sync_mode` to control how strictly events follow detected consonants.
+In **`bar`** mode the whole bar shifts toward the nearest consonant cluster,
+whereas **`note`** mode aligns kick and snare hits individually. The default is
+`bar` as shown in [`config/main_cfg.yml`](config/main_cfg.yml):
+
+```yaml
+global_settings:
+  use_consonant_sync: true
+  consonant_sync_mode: bar  # 'bar' or 'note'
+```
+
+You can override this on the command line:
+
+```bash
+python modular_composer.py --main-cfg config/main_cfg.yml --consonant-sync-mode note
+```
+
 Passing `--lag` values below zero will pre-hit the drums. If this causes
 negative beat offsets, set `clip_at_zero=true` in your configuration or pass the
 parameter when using the synchroniser programmatically.

--- a/docs/arrangement_features.md
+++ b/docs/arrangement_features.md
@@ -54,3 +54,22 @@ When calling the internal ``_apply_pattern()`` helper, note that the arguments
 after ``drum_block_params`` are ``velocity_scale`` followed by
 ``velocity_curve``. Passing them in the wrong order will produce unexpected
 velocity values. Using keyword arguments is recommended for clarity.
+
+## Consonant Sync Modes
+
+Drum events can be nudged toward detected consonants from your vocal track. The
+behaviour is controlled by `global_settings.consonant_sync_mode`.
+
+- **`bar`** – shift an entire bar toward the nearest consonant cluster.
+- **`note`** – align each kick and snare hit individually.
+
+The default is `bar` as illustrated in `config/main_cfg.yml`:
+
+```yaml
+global_settings:
+  use_consonant_sync: true
+  consonant_sync_mode: bar  # 'bar' or 'note'
+```
+
+Override the setting from the command line with `--consonant-sync-mode` when
+running `modular_composer.py`.


### PR DESCRIPTION
## Summary
- explain `consonant_sync_mode` in README
- document `bar` and `note` sync granularity in arrangement docs

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c480185388328b4f74306f7dbb969