### PR TITLE
Add safety check for consonant sync mode

### DIFF
--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -1241,6 +1241,14 @@ class DrumGenerator(BasePartGenerator):
             subdivision_duration_ql = beat_len_ql
         velocity_curve = velocity_curve or [1.0]
 
+        if self.use_consonant_sync and self.consonant_sync_mode not in {
+            "bar",
+            "note",
+        }:
+            raise ValueError(
+                f"invalid consonant_sync_mode '{self.consonant_sync_mode}'"
+            )
+
 
         if not events and self.groove_model:
             events = groove_sampler.generate_bar(


### PR DESCRIPTION
## Summary
- raise an error if an invalid `consonant_sync_mode` is given
- keep config and CLI options for consonant sync mode
- verify with tests

## Testing
- `pytest -q tests/test_consonant_sync.py::test_sync_modes -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c446b25848328bf7ab86210d1c68c