### PR TITLE
Validate consonant sync mode

### DIFF
--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -453,6 +453,11 @@ class DrumGenerator(BasePartGenerator):
         self.consonant_sync_mode = str(
             (global_settings or {}).get("consonant_sync_mode", "bar")
         ).lower()
+        if self.consonant_sync_mode not in {"bar", "note"}:
+            raise ValueError(
+                f"Invalid consonant sync mode: {self.consonant_sync_mode}."
+                " Expected 'bar' or 'note'."
+            )
 
         peak_json_path = (
             self.main_cfg.get("paths", {}).get("vocal_peak_json_for_drums")

--- a/tests/test_consonant_sync.py
+++ b/tests/test_consonant_sync.py
@@ -76,3 +76,14 @@ def test_sync_modes(tmp_path: Path, mode: str) -> None:
         assert offsets[1] == pytest.approx(1.0208, abs=1e-3)
         assert offsets[2] == pytest.approx(1.2708, abs=1e-3)
 
+
+def test_invalid_mode_raises(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path, "foo")
+    with pytest.raises(ValueError):
+        DrumGenerator(
+            main_cfg=cfg,
+            global_settings=cfg["global_settings"],
+            part_name="drums",
+            part_parameters={},
+        )
+


### PR DESCRIPTION
## Summary
- validate consonant sync mode in DrumGenerator
- test ValueError when invalid consonant sync mode is provided

## Testing
- `pytest tests/test_consonant_sync.py::test_invalid_mode_raises -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4803aac48328a9afe057a5f0c5f4