### PR TITLE
Fix drum accent step range update timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ Alternatively run `make` directly:
 bash -c "make demo && echo 'OK'"
 ```
 
+## Velocity Random Walk debug CC
+
+Enable `export_random_walk_cc: true` under `global_settings` to export the
+random walk value as MIDI CC20 once per bar. The CC value is scaled so 64
+represents no offset and values stay within the 0–127 range.
+The bar's absolute start offset (`bar_start_abs_offset`) is passed through so timings match the score.
+
 If the command finishes without errors you should see the message:
 
 ```

--- a/docs/api/drum_generator.md
+++ b/docs/api/drum_generator.md
@@ -42,6 +42,15 @@ dg = DrumGenerator(main_cfg=my_cfg, global_settings=cli_args)
 part = dg.compose(section_data=my_section)
 ```
 
+### Global Settings
+
+- `walk_after_ema` (bool): when `use_velocity_ema` is enabled, controls whether
+  the random walk is applied after smoothing (`True`) or before (`False`).
+- `export_random_walk_cc` (bool): if `True`, writes the random walk value to
+  controller **20** once per bar for debugging.
+- `random_walk_step` (int): base step range of the velocity random walk.
+- `bar_start_abs_offset` is forwarded to `AccentMapper.begin_bar` so debug CC timings align.
+
 #### `compose(self, *, section_data: Optional[Dict[str, Any]] = None, overrides_root: Optional[Any] = None, groove_profile_path: Optional[str] = None, next_section_data: Optional[Dict[str, Any]] = None, part_specific_humanize_params: Optional[Dict[str, Any]] = None, shared_tracks: Dict[str, Any] | None = None) -> stream.Part`
 ```python
 def compose(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
   "pytest",
   "mypy",
   "ruff",
+  "mido>=1.2",
 ]
 audio = [
   "librosa>=0.10",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 hypothesis>=6
+mido>=1.2

--- a/tests/test_midi_export_cc.py
+++ b/tests/test_midi_export_cc.py
@@ -1,0 +1,20 @@
+import pytest
+pytest.importorskip("mido")
+from music21 import stream, note
+from utilities.midi_export import music21_to_mido
+
+
+def test_extra_cc_written():
+    part = stream.Part(id="p")
+    n = note.Note("C4", quarterLength=1.0)
+    n.volume.velocity = 90
+    part.insert(0.0, n)
+    part.extra_cc = [{"time": 0.0, "number": 20, "value": 64}]
+    mid = music21_to_mido(part)
+    msgs = [
+        msg
+        for track in mid.tracks
+        for msg in track
+        if msg.type == "control_change" and msg.control == 20
+    ]
+    assert len(msgs) == 1

--- a/tests/test_velocity_random_walk.py
+++ b/tests/test_velocity_random_walk.py
@@ -1,6 +1,9 @@
 import random
 
 from utilities.accent_mapper import AccentMapper
+from utilities.velocity_smoother import EMASmoother
+from generator.drum_generator import DrumGenerator, RESOLUTION, INTENSITY_FACTOR
+from music21 import stream
 
 def test_velocity_random_walk_per_bar():
     rng = random.Random(0)
@@ -24,4 +27,195 @@ def test_velocity_random_walk_per_bar():
         for v in velocities
     )
     assert all(d <= 2 * step_range for d in diffs)
+
+
+def test_walk_after_ema_order_change():
+    heatmap = {0: 0}
+    base_settings = {
+        "accent_threshold": 0.0,
+        "ghost_density_range": (0.3, 0.8),
+        "random_walk_step": 4,
+    }
+    rng_seed = 1
+    a = AccentMapper(
+        heatmap,
+        {**base_settings, "walk_after_ema": False},
+        rng=random.Random(rng_seed),
+        ema_smoother=EMASmoother(),
+        use_velocity_ema=True,
+        walk_after_ema=False,
+    )
+    b = AccentMapper(
+        heatmap,
+        {**base_settings, "walk_after_ema": True},
+        rng=random.Random(rng_seed),
+        ema_smoother=EMASmoother(),
+        use_velocity_ema=True,
+        walk_after_ema=True,
+    )
+    vals_a = []
+    vals_b = []
+    for _ in range(6):
+        a.begin_bar()
+        b.begin_bar()
+        vals_a.append(a.accent(0, 80))
+        vals_b.append(b.accent(0, 80))
+    assert vals_a != vals_b
+
+
+def test_intensity_step_scaling(tmp_path):
+    heatmap = [{"grid_index": i, "count": 0} for i in range(RESOLUTION)]
+    heatmap_path = tmp_path / "h.json"
+    import json
+    with open(heatmap_path, "w") as f:
+        json.dump(heatmap, f)
+    cfg = {
+        "vocal_midi_path_for_drums": "",
+        "heatmap_json_path_for_drums": str(heatmap_path),
+        "global_settings": {"random_walk_step": 8},
+        "paths": {"drum_pattern_files": []},
+        "rng_seed": 0,
+    }
+    pattern = {"main": {"pattern": [{"instrument": "snare", "offset": 0.0}], "length_beats": 4.0, "velocity_base": 80}}
+    gen = DrumGenerator(
+        main_cfg=cfg,
+        part_name="drums",
+        part_parameters=pattern,
+        global_settings=cfg["global_settings"],
+    )
+    part_low = stream.Part(id="drums")
+    low_step = int(8 * INTENSITY_FACTOR["low"])
+    for bar in range(8):
+        gen.accent_mapper.begin_bar(bar * 4.0, low_step)
+        gen._apply_pattern(
+            part_low,
+            pattern["main"]["pattern"],
+            bar * 4.0,
+            4.0,
+            80,
+            "eighth",
+            0.5,
+            gen.global_ts,
+            {"musical_intent": {"intensity": "low"}},
+        )
+    v_low = [n.volume.velocity for n in part_low.flatten().notes]
+    range_low = max(v_low) - min(v_low)
+
+    part_high = stream.Part(id="drums")
+    high_step = int(8 * INTENSITY_FACTOR["high"])
+    for bar in range(8):
+        gen.accent_mapper.begin_bar(bar * 4.0, high_step)
+        gen._apply_pattern(
+            part_high,
+            pattern["main"]["pattern"],
+            bar * 4.0,
+            4.0,
+            80,
+            "eighth",
+            0.5,
+            gen.global_ts,
+            {"musical_intent": {"intensity": "high"}},
+        )
+    v_high = [n.volume.velocity for n in part_high.flatten().notes]
+    range_high = max(v_high) - min(v_high)
+
+    assert range_high > range_low
+
+
+def test_random_walk_cc_export(tmp_path):
+    heatmap = [{"grid_index": i, "count": 0} for i in range(RESOLUTION)]
+    heatmap_path = tmp_path / "h.json"
+    import json
+    with open(heatmap_path, "w") as f:
+        json.dump(heatmap, f)
+    cfg = {
+        "vocal_midi_path_for_drums": "",
+        "heatmap_json_path_for_drums": str(heatmap_path),
+        "global_settings": {
+            "random_walk_step": 4,
+            "export_random_walk_cc": True,
+        },
+        "paths": {"drum_pattern_files": []},
+        "rng_seed": 0,
+    }
+    pattern = {"main": {"pattern": [{"instrument": "snare", "offset": 0.0}], "length_beats": 4.0, "velocity_base": 80}}
+    gen = DrumGenerator(
+        main_cfg=cfg,
+        part_name="drums",
+        part_parameters=pattern,
+        global_settings=cfg["global_settings"],
+    )
+    part = stream.Part(id="drums")
+    mid_step = int(4 * INTENSITY_FACTOR["medium"])
+    for bar in range(2):
+        gen.accent_mapper.begin_bar(bar * 4.0, mid_step)
+        gen._apply_pattern(
+            part,
+            pattern["main"]["pattern"],
+            bar * 4.0,
+            4.0,
+            80,
+            "eighth",
+            0.5,
+            gen.global_ts,
+            {"musical_intent": {"intensity": "medium"}},
+        )
+    cc20 = [c for c in getattr(part, "extra_cc", []) if c["number"] == 20]
+    assert len(cc20) == 2
+
+
+def test_begin_bar_once_per_bar(tmp_path):
+    heatmap = [{"grid_index": i, "count": 0} for i in range(RESOLUTION)]
+    h = tmp_path / "hm.json"
+    import json
+    with open(h, "w") as f:
+        json.dump(heatmap, f)
+
+    cfg = {
+        "vocal_midi_path_for_drums": "",
+        "heatmap_json_path_for_drums": str(h),
+        "global_settings": {"random_walk_step": 4},
+        "paths": {"drum_pattern_files": []},
+        "rng_seed": 0,
+    }
+    pattern = {"main": {"pattern": [{"instrument": "snare", "offset": 0.0}], "length_beats": 4.0, "velocity_base": 80}}
+    gen = DrumGenerator(
+        main_cfg=cfg,
+        part_name="drums",
+        part_parameters=pattern,
+        global_settings=cfg["global_settings"],
+    )
+    section = {
+        "section_name": "X",
+        "absolute_offset": 0.0,
+        "q_length": 8.0,
+        "musical_intent": {},
+        "part_params": {},
+    }
+    from unittest.mock import patch
+
+    with patch.object(gen.accent_mapper, "begin_bar", wraps=gen.accent_mapper.begin_bar) as mock_b:
+        gen.compose(section_data=section)
+        assert mock_b.call_count == 2
+
+
+def test_drum_global_settings_persist():
+    dg = DrumGenerator(main_cfg={}, part_name="drums", part_parameters={}, global_settings={"random_walk_step": 6})
+    assert dg.global_settings["random_walk_step"] == 6
+
+
+def test_begin_bar_records_offset():
+    am = AccentMapper({}, {"random_walk_step": 4})
+    am.begin_bar(8.0)
+    assert am.debug_rw_values[-1][0] == 8.0
+
+
+def test_step_range_updates_immediately():
+    am = AccentMapper({}, {"random_walk_step": 8})
+    low_step = int(8 * INTENSITY_FACTOR["low"])
+    high_step = int(8 * INTENSITY_FACTOR["high"])
+    am.begin_bar(0.0, low_step)
+    assert am._step_range == low_step
+    am.begin_bar(4.0, high_step)
+    assert am._step_range == high_step
 

--- a/utilities/midi_export.py
+++ b/utilities/midi_export.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
+import io
 
+try:  # pragma: no cover - optional dependency for export helpers
+    import mido
+except ImportError:  # pragma: no cover - handled gracefully in functions
+    mido = None
 import pretty_midi
+from music21 import stream
+from music21.midi import translate
 
 
 def write_demo_bar(path: str | Path) -> Path:
@@ -18,3 +26,44 @@ def write_demo_bar(path: str | Path) -> Path:
     pm.instruments.append(inst)
     pm.write(str(out_path))
     return out_path
+
+
+def append_extra_cc(
+    part: stream.Part,
+    track: "mido.MidiTrack",
+    to_ticks: Callable[[float], int],
+    *,
+    channel: int = 0,
+) -> None:
+    """Append extra CC events from ``part`` to the given ``track``."""
+    if mido is None:
+        return
+    if hasattr(part, "extra_cc"):
+        for cc in part.extra_cc:
+            track.append(
+                mido.Message(
+                    "control_change",
+                    time=to_ticks(cc["time"]),
+                    control=int(cc["number"]),
+                    value=int(cc["value"]),
+                    channel=channel,
+                )
+            )
+
+
+def music21_to_mido(part: stream.Part) -> "mido.MidiFile":
+    """Convert a ``music21`` part to ``mido.MidiFile`` preserving ``extra_cc``."""
+    if mido is None:  # pragma: no cover - optional dependency
+        raise ImportError("mido is required to export MIDI")
+
+    mf = translate.streamToMidiFile(part)
+    data = mf.writestr()
+    midi = mido.MidiFile(file=io.BytesIO(data))
+
+    def to_ticks(ql: float) -> int:
+        return int(round(ql * midi.ticks_per_beat))
+
+    if midi.tracks:
+        append_extra_cc(part, midi.tracks[0], to_ticks)
+    return midi
+


### PR DESCRIPTION
## Summary
- update dev requirements and optional deps to include mido
- allow `AccentMapper.begin_bar` to update step range on call
- set the random-walk step range before starting each bar
- guard extra CC export when debug list missing
- skip CC export test if mido is missing
- test immediate step range updates and new begin_bar API

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c4eeea8f08328b43028ab07863b8b