### PR TITLE
Implement tom-run DSL fills

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,21 @@ If the command finishes without errors you should see the message:
 drum_patterns の duration 欠損が解消されました
 ```
 
+## 標準パターン拡充
+
+`data/drum_patterns.yml` に `tom_dsl_fill` タイプのフィルを追加しました。以下のように簡潔な DSL でタム回しを記述できます。
+
+```yaml
+tom_run_short:
+  description: "1 小節前半にタム回し"
+  pattern_type: "tom_dsl_fill"
+  length_beats: 1.0
+  drum_base_velocity: 88
+  pattern: |
+    (T1 T2 T3 S)
+```
+`export_random_walk_cc: true` を設定すると、ランダムウォーク値を CC20 として書き出せます。
+
 ## Running Tests
 
 Be sure you have installed the requirements via `bash setup.sh` (or

--- a/data/drum_patterns.yml
+++ b/data/drum_patterns.yml
@@ -283,6 +283,22 @@ drum_patterns:
         offset: 4.0
         duration: 1.0
 
+  tom_run_short:
+    description: "1 小節前半にタム回し"
+    pattern_type: "tom_dsl_fill"
+    length_beats: 1.0
+    drum_base_velocity: 88
+    pattern: |
+      (T1 T2 T3 S)x1
+
+  tom_cascade:
+    description: "下降タム＋キック〆"
+    pattern_type: "tom_dsl_fill"
+    length_beats: 1.0
+    drum_base_velocity: 92
+    pattern: |
+      >1.1 T3 T2 T1 . K
+
   ghost_hat_ballad:
     description: "静かなバラードでの繊細な表現"
     pattern_type: "simple"
@@ -600,6 +616,7 @@ cymbal_swell_fill:
     - instrument: crash
       offset: 4.0
 
+
 # --- ゴーストノート多用型 ---
 ghost_hat_ballad:
   description: "静かなバラードでの繊細な表現"
@@ -693,31 +710,6 @@ default_drum_pattern:
       velocity_factor: 1.0
       duration: 0.15
 
-drum_patterns:
-  default_drum_pattern:
-    description: "Default simple kick and snare (Global Fallback)."
-    time_signature: "4/4"
-    pattern_type: "fixed_pattern"
-    length_beats: 4.0
-    drum_base_velocity: 90
-    tags: ["drum", "default", "minimal", "kick_snare"]
-    pattern:
-      - instrument: kick
-        offset: 0.0
-        velocity_factor: 1.0
-        duration: 0.15
-      - instrument: snare
-        offset: 1.0
-        velocity_factor: 1.0
-        duration: 0.15
-      - instrument: kick
-        offset: 2.0
-        velocity_factor: 1.0
-        duration: 0.15
-      - instrument: snare
-        offset: 3.0
-        velocity_factor: 1.0
-        duration: 0.15
 
   ballad_soft_kick_snare_8th_hat:
     description: "Refined soft ballad with subtle ghost snare and expressive hats."

--- a/docs/api/drum_generator.md
+++ b/docs/api/drum_generator.md
@@ -155,4 +155,21 @@ Example:
 dg._insert_grace_chain(part, 1.0, 38, 90, n_hits=3)
 ```
 
+### Tom DSL Fill Patterns
+
+`FillInserter` supports a compact DSL for tom fills when `pattern_type` is set to `"tom_dsl_fill"`.
+Tokens like `T1`, `T2`, `T3`, `K` and `S` trigger drum hits, `+` extends the previous hit by a 16th note and `.` inserts a rest. Velocity modifiers such as `>1.2` scale the next hit, groups may repeat using `( ... )xN` (or default to one time when `xN` is omitted) and `@N` jumps to an absolute 16th offset.
+
+Example YAML pattern:
+
+```yaml
+tom_run_short:
+  description: "1 小節前半にタム回し"
+  pattern_type: "tom_dsl_fill"
+  length_beats: 1.0
+  drum_base_velocity: 88
+  pattern: |
+    (T1 T2 T3 S)
+```
+
 

--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -167,10 +167,19 @@ class FillInserter:
         if fill_def is None:
             logger.warning("FillInserter.insert: fill pattern '%s' not found", key)
             return
+        pattern_type = str(fill_def.get("pattern_type", "")).lower()
         template = fill_def.get("template")
         if isinstance(template, list):
             template = self.rng.choice(template)
-        if template is not None:
+
+        if pattern_type == "tom_dsl_fill":
+            dsl = str(fill_def.get("pattern", ""))
+            try:
+                events = fill_dsl.parse_fill_dsl(dsl)
+            except fill_dsl.FillDSLParseError as exc:
+                logger.warning("FillInserter.insert: DSL parse error: %s", exc)
+                return
+        elif template is not None:
             events = fill_dsl.parse(
                 str(template),
                 fill_def.get("length_beats", 1.0),

--- a/tests/test_drum_lint.py
+++ b/tests/test_drum_lint.py
@@ -14,3 +14,22 @@ def test_rhythm_library_lint_unknown_instruments():
     path = Path(__file__).resolve().parents[1] / "data" / "rhythm_library.yml"
     unknown = check_rhythm_library(path)
     assert unknown == set()
+
+
+def test_dsl_pattern_lint(tmp_path):
+    from utilities.drum_lint import check_drum_patterns
+    import yaml
+
+    data = {
+        "drum_patterns": {
+            "demo": {
+                "pattern_type": "tom_dsl_fill",
+                "pattern": "(T1 K)"
+            }
+        }
+    }
+    p = tmp_path / "p.yml"
+    with p.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, allow_unicode=True)
+    unknown = check_drum_patterns(p)
+    assert unknown == set()

--- a/tests/test_drum_mapping.py
+++ b/tests/test_drum_mapping.py
@@ -19,9 +19,19 @@ def test_all_drum_keys_mapped():
             else:
                 library.update(doc)
 
+    from utilities.fill_dsl import parse_fill_dsl
+
     inst_names = set()
     for pat in library.values():
-        for ev in pat.get('pattern', []):
+        pattern_data = pat.get('pattern', [])
+        if isinstance(pattern_data, str):
+            try:
+                events = parse_fill_dsl(pattern_data)
+            except Exception:
+                continue
+        else:
+            events = pattern_data
+        for ev in events:
             name = ev.get('instrument')
             if name:
                 inst_names.add(name.lower())

--- a/tests/test_tom_fill_dsl.py
+++ b/tests/test_tom_fill_dsl.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+
+import pytest
+from music21 import stream, meter
+
+from utilities.fill_dsl import parse_fill_dsl, FillDSLParseError
+from generator.drum_generator import DrumGenerator, GM_DRUM_MAP
+
+
+def _cfg(tmp_path: Path) -> dict:
+    heatmap = [{"grid_index": i, "count": 0} for i in range(16)]
+    hp = tmp_path / "heatmap.json"
+    with hp.open("w") as f:
+        json.dump(heatmap, f)
+    return {
+        "vocal_midi_path_for_drums": "",
+        "heatmap_json_path_for_drums": str(hp),
+        "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
+        "rng_seed": 0,
+    }
+
+
+def test_parse_fill_dsl_basic():
+    ev = parse_fill_dsl("(T1 T2 T3 S)x1")
+    assert [e["instrument"] for e in ev] == ["tom1", "tom2", "tom3", "snare"]
+    assert [e["offset"] for e in ev] == pytest.approx([0.0, 0.25, 0.5, 0.75])
+
+
+def test_parse_fill_dsl_velocity_and_rest():
+    ev = parse_fill_dsl(">1.1 T3 T2 T1 . K")
+    assert ev[0]["velocity_factor"] == pytest.approx(1.1)
+    assert ev[-1]["instrument"] == "kick"
+    assert ev[-1]["offset"] == pytest.approx(1.0)
+
+
+def test_apply_pattern_from_dsl(tmp_path: Path):
+    gen = DrumGenerator(main_cfg=_cfg(tmp_path), part_name="drums", part_parameters={})
+    part = stream.Part(id="drums")
+    events = parse_fill_dsl("T1 T2")
+    gen._apply_pattern(
+        part,
+        events,
+        0.0,
+        1.0,
+        90,
+        "eighth",
+        0.5,
+        meter.TimeSignature("4/4"),
+        {},
+    )
+    midi = [n.pitch.midi for n in part.flatten().notes]
+    assert midi == [GM_DRUM_MAP["tom1"][1], GM_DRUM_MAP["tom2"][1]]
+
+
+def test_no_duplicate_keys_in_patterns():
+    import yaml
+
+    class UniqueLoader(yaml.SafeLoader):
+        pass
+
+    def construct_mapping(loader, node, deep=False):
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in mapping:
+                raise ValueError(f"Duplicate key: {key}")
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    UniqueLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping
+    )
+
+    with open("data/drum_patterns.yml", "r", encoding="utf-8") as fh:
+        yaml.load(fh, Loader=UniqueLoader)
+
+
+def test_group_repeat_optional():
+    ev = parse_fill_dsl("(T1 T2)")
+    assert [e["instrument"] for e in ev] == ["tom1", "tom2"]
+


### PR DESCRIPTION
## Summary
- extend fill_dsl with default x1 for group repeats
- skip non-dict events in drum_lint helpers
- load tom DSL patterns in mapping test via parse_fill_dsl
- remove duplicate tom DSL entries from drum_patterns.yml
- document new DSL behavior
- parse tom DSL patterns during linting, guard offset tokens
- remove duplicated default pattern and mention `export_random_walk_cc`

## Testing
- `bash setup.sh`
- `pytest -q`
- `PYTHONPATH=. mkdocs build` *(fails: The `pdoc` plugin is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ca3ed5c4883288ab367de62901dc3