### PR TITLE
Improve consonant peak extractor reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,22 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e ".[dev]"
+      - name: Restore Essentia wheel cache
+        if: runner.os == 'Linux'
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip/wheels
+          key: ${{ runner.os }}-essentia-2_1
+      - name: Install Essentia extras
+        if: runner.os == 'Linux'
+        run: |
+          pip install -e ".[essentia]"
+      - name: Save Essentia wheel cache
+        if: runner.os == 'Linux'
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip/wheels/**/essentia*.whl
+          key: ${{ runner.os }}-essentia-2_1
       - name: Cache SoundFont
         id: cache-sf2
         uses: actions/cache@v3
@@ -41,7 +57,10 @@ jobs:
       - name: Mypy
         run: mypy modular_composer utilities tests --strict
       - name: Pytest
-        run: pytest -q --cov --cov-report=xml
+        run: pytest -q -m "not ess_optional" --cov --cov-report=xml
+      - name: Pytest Essentia
+        if: runner.os == 'Linux'
+        run: pytest -q -m ess_optional --cov --cov-append
       - name: MIDI Regression Tests
         run: pytest tests/test_midi_regression.py
         env:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ or equivalently
 
 ```bash
 pip install -r requirements.txt
+pip install -e ".[essentia]"  # to enable Essentia backend for consonant peaks
 ```
 
 Without these packages `pytest` and the composer modules will fail to import.
@@ -275,6 +276,18 @@ saved to JSON so they can be used for later synchronization tools:
 
 ```bash
 modcompose peaks path/to/vocal.wav -o peaks.json --plot
+```
+
+Alternatively you can invoke the extraction helper directly:
+
+```bash
+python -m utilities.consonant_extract path/to/vocal.wav -o peaks.json
+```
+
+To use the Essentia backend:
+
+```bash
+modcompose peaks vocal.wav -o peaks.json --algo essentia
 ```
 
 Use the JSON with the sampler to synchronise drums with consonants:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ audio = [
   "soundfile>=0.12",
   "fluidsynth",
 ]
+essentia = [
+  "essentia>=2.1",
+]
 
 [project.scripts]
 modcompose = "modular_composer.cli:main"

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,8 @@ testpaths =
     tools
 norecursedirs = アーカイブ
 addopts = --dry-run
+markers =
+    ess_optional: tests that require the Essentia backend
 
 [tool:pytest]
 filterwarnings =

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 hypothesis>=6
 mido>=1.2
+librosa>=0.10

--- a/tests/test_consonant_extract.py
+++ b/tests/test_consonant_extract.py
@@ -1,0 +1,71 @@
+import json
+import subprocess
+import tempfile
+import wave
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from utilities.consonant_extract import (
+    EssentiaUnavailable,
+    detect_consonant_peaks,
+)
+
+np.random.seed(0)
+
+
+def synth_voice(peaks: list[float], sr: int = 16000, length: float = 1.0) -> np.ndarray:
+    """Return synthetic signal with short noise bursts at ``peaks`` seconds."""
+    n = int(length * sr)
+    sig = np.zeros(n)
+    for t in peaks:
+        idx = int(t * sr)
+        if 0 <= idx < n:
+            sig[idx: idx + int(0.01 * sr)] += np.random.randn(int(0.01 * sr)) * 0.5
+    return sig
+
+
+def write_wav(path: Path, data: np.ndarray, sr: int = 16000) -> None:
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sr)
+        wf.writeframes((data * 32767).astype(np.int16).tobytes())
+
+
+@pytest.mark.parametrize("peaks", [[0.2, 0.6, 0.8]])
+def test_detect_consonant_peaks(peaks):
+    sig = synth_voice(peaks)
+    with tempfile.TemporaryDirectory() as td:
+        wav_path = Path(td) / "test.wav"
+        write_wav(wav_path, sig)
+        detected = detect_consonant_peaks(wav_path, thr=0.2)
+        assert len(detected) >= len(peaks)
+
+
+def test_cli_outputs_json(tmp_path: Path) -> None:
+    wav = tmp_path / "v.wav"
+    sig = synth_voice([0.1, 0.5])
+    write_wav(wav, sig)
+    out_json = tmp_path / "p.json"
+    subprocess.run(
+        ["python", "-m", "modular_composer.cli", "peaks", str(wav), "-o", str(out_json)],
+        check=True,
+    )
+    assert out_json.exists()
+    with out_json.open() as fh:
+        data = json.load(fh)
+    assert data == sorted(data)
+
+
+@pytest.mark.ess_optional
+def test_essentia_backend(tmp_path: Path) -> None:
+    wav = tmp_path / "v.wav"
+    sig = synth_voice([0.1, 0.5])
+    write_wav(wav, sig)
+    try:
+        peaks = detect_consonant_peaks(wav, thr=0.2, algo="essentia")
+    except EssentiaUnavailable:
+        pytest.skip("Essentia not installed")
+    assert len(peaks) >= 2

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -18,6 +18,11 @@ utilities package -- 音楽生成プロジェクト全体で利用されるコ�
 """
 
 from .accent_mapper import AccentMapper
+from .consonant_extract import (
+    EssentiaUnavailable,
+    detect_consonant_peaks,
+    extract_to_json,
+)
 from .core_music_utils import (
     MIN_NOTE_DURATION_QL,
     get_time_signature_object,
@@ -80,4 +85,7 @@ __all__ = [
     "write_demo_bar",
     "render_midi",
     "AccentMapper",
+    "EssentiaUnavailable",
+    "detect_consonant_peaks",
+    "extract_to_json",
 ]

--- a/utilities/consonant_extract.py
+++ b/utilities/consonant_extract.py
@@ -1,0 +1,144 @@
+# utilities/consonant_extract.py
+"""Consonant peak extraction utilities.
+
+This module provides a small CLI and a helper function to detect
+fricative/consonant-like peaks from WAV files.  The implementation
+relies on ``librosa`` for onset strength calculation with optional
+high-pass/low-pass filtering.  Essentia spectral flux can be used
+when the library is available.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+import librosa
+import numpy as np
+from scipy.signal import butter, filtfilt, find_peaks
+
+
+class EssentiaUnavailable(RuntimeError):
+    """Raised when the Essentia backend is requested but not installed."""
+
+_DEF_WIN = 2048
+_DEF_HOP = 512
+_DEF_THR = 0.25
+
+
+def _apply_filters(
+    y: np.ndarray,
+    sr: int,
+    hpf: float | None = None,
+    lpf: float | None = None,
+) -> np.ndarray:
+    nyq = 0.5 * sr
+    if hpf is not None:
+        if hpf >= nyq:
+            raise ValueError("hpf cutoff must be below Nyquist")
+        b, a = butter(2, hpf / nyq, btype="highpass")
+        padlen = 3 * (max(len(a), len(b)) - 1)
+        if len(y) <= padlen:
+            logging.warning(
+                "input length (%d) <= padlen (%d); skipping high-pass filter",
+                len(y),
+                padlen,
+            )
+        else:
+            y = filtfilt(b, a, y)
+    if lpf is not None:
+        if lpf >= nyq:
+            raise ValueError("lpf cutoff must be below Nyquist")
+        b, a = butter(2, lpf / nyq, btype="lowpass")
+        padlen = 3 * (max(len(a), len(b)) - 1)
+        if len(y) <= padlen:
+            logging.warning(
+                "input length (%d) <= padlen (%d); skipping low-pass filter",
+                len(y),
+                padlen,
+            )
+        else:
+            y = filtfilt(b, a, y)
+    return y
+
+
+def detect_consonant_peaks(
+    wav_path: str | Path,
+    *,
+    algo: str = "librosa",
+    window: int = _DEF_WIN,
+    hop: int = _DEF_HOP,
+    thr: float = _DEF_THR,
+    hpf: float | None = None,
+    lpf: float | None = None,
+) -> list[float]:
+    """Return peak times in seconds from ``wav_path``."""
+    path = Path(wav_path)
+    y, sr = librosa.load(path, sr=None, mono=True)
+    y = _apply_filters(y, sr, hpf, lpf)
+
+    algo = algo.lower()
+    if algo == "librosa":
+        onset_env = librosa.onset.onset_strength(
+            y=y, sr=sr, hop_length=hop, n_fft=window
+        )
+    elif algo == "essentia":
+        try:
+            import essentia.standard as ess
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise EssentiaUnavailable("Essentia not installed") from exc
+        flux = ess.SpectralFlux()
+        spectrum = ess.Spectrum()
+        frames = ess.FrameGenerator(y, frameSize=window, hopSize=hop, startFromZero=True)
+        onset_env = [flux(spectrum(f)) for f in frames]
+        onset_env = np.array(onset_env)
+    else:
+        raise ValueError(f"Unsupported algorithm: {algo}")
+
+    if onset_env.size == 0:
+        return []
+    thr_val = thr * float(np.max(onset_env))
+    peaks, _ = find_peaks(onset_env, height=thr_val)
+    times = librosa.frames_to_time(peaks, sr=sr, hop_length=hop)
+    return times.tolist()
+
+
+def extract_to_json(
+    wav_path: str | Path,
+    out_path: str | Path,
+    **kwargs: object,
+) -> list[float]:
+    times = detect_consonant_peaks(wav_path, **kwargs)
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(times, indent=2))
+    return times
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Extract consonant peaks")
+    parser.add_argument("input_wav")
+    parser.add_argument("-o", "--output", default="consonant_peaks.json")
+    parser.add_argument("--algo", default="librosa")
+    parser.add_argument("--window", type=int, default=_DEF_WIN)
+    parser.add_argument("--hop", type=int, default=_DEF_HOP)
+    parser.add_argument("--thr", type=float, default=_DEF_THR)
+    parser.add_argument("--hpf", type=float, default=None)
+    parser.add_argument("--lpf", type=float, default=None)
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    extract_to_json(
+        args.input_wav,
+        args.output,
+        algo=args.algo,
+        window=args.window,
+        hop=args.hop,
+        thr=args.thr,
+        hpf=args.hpf,
+        lpf=args.lpf,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- guard filter cutoffs and short signals in `consonant_extract`
- ensure CLI writes to new directories
- seed test data and loosen assertion
- declare `essentia` optional dependency and add librosa to dev requirements
- document optional install command
- export `detect_consonant_peaks` and `extract_to_json` through the utilities package
- add CLI wrapper `modcompose peaks`
- allow optional Essentia tests in CI
- register `ess_optional` marker and add optional Essentia test
- cache Essentia wheels in CI

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d393dcb588328a014030042688ccc