### PR TITLE
Implement GrooveSampler ngram module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ or equivalently
 ```bash
 pip install -r requirements.txt
 pip install -e ".[essentia]"  # to enable Essentia backend for consonant peaks
+pip install click  # required for the groove sampler CLI
+pip install -e .[audio]  # optional, enables WAV groove extraction
 ```
 
 Without these packages `pytest` and the composer modules will fail to import.
@@ -249,13 +251,12 @@ absent, the spectrum test will be skipped.
 
 ### Groove Sampler Usage
 
-Build an n-gram model from a folder of MIDI loops:
+Train a groove model and generate MIDI directly via the CLI:
 
 ```bash
-python -m utilities.groove_sampler data/loops --stats
+modcompose groove train data/loops --ext midi --out model.pkl
+modcompose groove sample model.pkl -l 4 --temperature 0.8 --seed 42 > groove.mid
 ```
-
-The command prints detected resolution and the chosen order.
 
 ### Groove Sampler v2
 

--- a/docs/groove_sampler.md
+++ b/docs/groove_sampler.md
@@ -1,0 +1,20 @@
+# Groove Sampler
+
+Train an n-gram model from a folder of MIDI or WAV loops.
+
+Install optional dependencies to enable WAV extraction and the CLI:
+
+```bash
+pip install click
+pip install -e .[audio]
+```
+
+```bash
+modcompose groove train loops/ --ext midi --out model.pkl
+```
+
+Generate a four bar MIDI groove:
+
+```bash
+modcompose groove sample model.pkl -l 4 --temperature 0.8 --seed 42 > out.mid
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,5 @@
 Welcome to the documentation for **Composer2**, a framework that merges poetic Japanese narration with emotive music generation. This project automatically composes instrumental parts and rhythmic backing for each chapter of your story.
 
 Browse the API reference to learn how to integrate the generators into your workflow.
+
+See [Groove Sampler](groove_sampler.md) for training drum models.

--- a/examples/groove_sampler.ipynb
+++ b/examples/groove_sampler.ipynb
@@ -1,0 +1,15 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Groove Sampler\n",
+    "This notebook demonstrates training and sampling a simple n-gram drum model."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ nav:
   - Home: index.md
   - API Reference:
       - DrumGenerator: docs/api/drum_generator.md
+  - Groove Sampler: docs/groove_sampler.md
 plugins:
   - pdoc:
       module: generator.drum_generator

--- a/modular_composer/cli.py
+++ b/modular_composer/cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pretty_midi
 
-from utilities import synth
+from utilities import groove_sampler_ngram, synth
 from utilities.golden import compare_midi, update_golden
 from utilities.groove_sampler_v2 import generate_events, load, save, train  # noqa: F401
 from utilities.peak_synchroniser import PeakSynchroniser
@@ -106,7 +106,7 @@ def _cmd_render(args: list[str]) -> None:
     ns = ap.parse_args(args)
 
     if ns.spec.suffix.lower() in {".yml", ".yaml"}:
-        import yaml
+        import yaml  # type: ignore[import-untyped]
 
         with ns.spec.open("r", encoding="utf-8") as fh:
             spec = yaml.safe_load(fh) or {}
@@ -181,7 +181,7 @@ def main(argv: list[str] | None = None) -> None:
     if not argv or argv[0] in {"-h", "--help"}:
         print(
             "usage: modcompose <command> [<args>]\n\n"
-            "commands: demo, sample, peaks, render, gm-test"
+            "commands: demo, sample, peaks, render, gm-test, groove"
         )
         sys.exit(0)
     cmd, *rest = argv
@@ -195,6 +195,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_render(rest)
     elif cmd == "gm-test":
         _cmd_gm_test(rest)
+    elif cmd == "groove":
+        groove_sampler_ngram.main(rest)
     else:
         sys.exit(f"unknown command {cmd!r}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "pretty_midi>=0.2.10",
   "numpy>=1.26.4,<2.0.0",
   "PyYAML>=6.0",
+  "click>=8",
   "pydantic>=2.7",
   "pydub>=0.25",
   "mido>=1.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ music21>=9.6.0
 pretty_midi>=0.2.10
 numpy>=1.26.4,<2.0.0
 PyYAML>=6.0
+click>=8
 pydantic>=2.7
 pydub>=0.25
 mido>=1.3.0

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -17,12 +17,28 @@ utilities package -- 音楽生成プロジェクト全体で利用されるコ�
         - NUMPY_AVAILABLE
 """
 
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    from . import groove_sampler_ngram as groove_sampler_ngram
 from .accent_mapper import AccentMapper
-from .consonant_extract import (
-    EssentiaUnavailable,
-    detect_consonant_peaks,
-    extract_to_json,
-)
+
+try:
+    from .consonant_extract import (
+        EssentiaUnavailable,
+        detect_consonant_peaks,
+        extract_to_json,
+    )
+except Exception:  # pragma: no cover - optional dependency
+    class EssentiaUnavailable(RuntimeError):
+        """Raised when librosa-based peak extraction is unavailable."""
+
+    def detect_consonant_peaks(*_args: Any, **_kwargs: Any) -> list[float]:
+        raise EssentiaUnavailable("librosa is required for peak detection")
+
+    def extract_to_json(*_args: Any, **_kwargs: Any) -> None:
+        raise EssentiaUnavailable("librosa is required for peak detection")
 from .core_music_utils import (
     MIN_NOTE_DURATION_QL,
     get_time_signature_object,
@@ -84,8 +100,18 @@ __all__ = [
     "TempoVelocitySmoother",
     "write_demo_bar",
     "render_midi",
+    "get_drum_map",
     "AccentMapper",
     "EssentiaUnavailable",
     "detect_consonant_peaks",
     "extract_to_json",
+    "groove_sampler_ngram",
 ]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin wrapper
+    if name == "groove_sampler_ngram":
+        module = importlib.import_module("utilities.groove_sampler_ngram")
+        globals()[name] = module
+        return module
+    raise AttributeError(name)

--- a/utilities/drum_map_registry.py
+++ b/utilities/drum_map_registry.py
@@ -2,24 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Dict, Tuple, Union
-
 # ---------------------------------------------------------------------------
 # ① 共通で使う定数
 # ---------------------------------------------------------------------------
 
-HH_EDGE: Tuple[str, int] = ("closed_hi_hat_edge", 22)
+HH_EDGE: tuple[str, int] = ("closed_hi_hat_edge", 22)
 """GM note mapping for closed hi-hat "edge" sample."""
 
-HH_PEDAL: Tuple[str, int] = ("pedal_hi_hat", 44)
+HH_PEDAL: tuple[str, int] = ("pedal_hi_hat", 44)
 """GM note mapping for hi-hat pedal "chick"."""
-SNARE_RUFF: Tuple[str, int] = ("acoustic_snare", 38)
+SNARE_RUFF: tuple[str, int] = ("acoustic_snare", 38)
 
 # ---------------------------------------------------------------------------
 # ② GM ベース (infra/zero-green 起点)
 # ---------------------------------------------------------------------------
 
-GM_DRUM_MAP: Dict[str, Tuple[str, int]] = {
+GM_DRUM_MAP: dict[str, tuple[str, int]] = {
     # Hi-hat
     "chh": ("closed_hi_hat", 42),
     "hh": ("closed_hi_hat", 42),
@@ -48,6 +46,7 @@ GM_DRUM_MAP: Dict[str, Tuple[str, int]] = {
     # FX
     "chimes": ("triangle", 81),
     "shaker_soft": ("shaker", 82),
+    "perc": ("shaker", 82),
     # Brushes
     "brush_kick": ("acoustic_bass_drum", 36),
     "brush_snare": ("acoustic_snare", 38),
@@ -75,9 +74,10 @@ _LEGEND_BASE = {
         "splash",
         "crash_choke",
         "cowbell",
+        "perc",
     }
 }
-UJAM_LEGEND_MAP: Dict[str, Tuple[str, int]] = {
+UJAM_LEGEND_MAP: dict[str, tuple[str, int]] = {
     **_LEGEND_BASE,  # まず GM をベースにコピーし、一部だけ差し替え
     "kick": ("acoustic_bass_drum", 36),
     "snare": ("acoustic_snare", 38),
@@ -91,11 +91,11 @@ UJAM_LEGEND_MAP: Dict[str, Tuple[str, int]] = {
 # ---------------------------------------------------------------------------
 
 
-def _mk(desc: str, note: int) -> Tuple[str, int]:
+def _mk(desc: str, note: int) -> tuple[str, int]:
     return desc, note
 
 
-BEATMAKER_V3_MAP: Dict[str, Tuple[str, int]] = {
+BEATMAKER_V3_MAP: dict[str, tuple[str, int]] = {
     "kick": _mk("kick", 36),
     "snare": _mk("snare", 38),
     "closed_hi_hat": _mk("closed_hi_hat", 42),
@@ -131,14 +131,14 @@ MISSING_DRUM_MAP_FALLBACK = {
 # ⑥ マップレジストリ & API
 # ---------------------------------------------------------------------------
 
-DRUM_MAPS: Dict[str, Dict[str, Tuple[str, int]]] = {
+DRUM_MAPS: dict[str, dict[str, tuple[str, int]]] = {
     "gm": GM_DRUM_MAP,
     "ujam_legend": UJAM_LEGEND_MAP,
     "beatmaker_v3": BEATMAKER_V3_MAP,
 }
 
 
-def _as_int_map(mapping: Dict[str, Tuple[str, int]]) -> Dict[str, int]:
+def _as_int_map(mapping: dict[str, tuple[str, int]]) -> dict[str, int]:
     """int だけ欲しい場合に変換して返す."""
     return {k: v[1] if isinstance(v, tuple) else v for k, v in mapping.items()}
 

--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -1,0 +1,307 @@
+"""Portable n-gram groove sampler."""
+
+from __future__ import annotations
+
+import io
+import pickle
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+from random import Random
+from typing import TypedDict
+
+import click
+import pretty_midi
+
+from .drum_map_registry import GM_DRUM_MAP
+
+PPQ = 480
+RESOLUTION = 16
+VERSION = 1
+ALPHA = 0.1
+
+
+# mapping from MIDI pitch to drum label
+_PITCH_TO_LABEL: dict[int, str] = {val[1]: k for k, val in GM_DRUM_MAP.items()}
+
+State = tuple[int, str]
+
+
+class Model(TypedDict):
+    """Container for the n-gram model."""
+
+    version: int
+    resolution: int
+    order: int
+    freq: dict[int, dict[tuple[State, ...], Counter[State]]]
+    prob: dict[int, dict[tuple[State, ...], dict[State, float]]]
+    mean_velocity: dict[str, float]
+    vel_deltas: dict[str, Counter[int]]
+    micro_offsets: dict[str, Counter[int]]
+
+
+def _iter_midi(path: Path) -> Iterator[tuple[float, str, int, int]]:
+    """Yield quantised events from a MIDI file."""
+
+    pm = pretty_midi.PrettyMIDI(str(path))
+    tempo = pm.get_tempo_changes()[1]
+    bpm = float(tempo[0]) if tempo.size else 120.0
+    sec_per_beat = 60.0 / bpm
+
+    for inst in pm.instruments:
+        if not inst.is_drum:
+            continue
+        for note in inst.notes:
+            beat = note.start / sec_per_beat
+            step = int(round(beat * (RESOLUTION / 4)))
+            q_pos = step / (RESOLUTION / 4)
+            micro = int(round((beat - q_pos) * PPQ))
+            label = _PITCH_TO_LABEL.get(note.pitch, str(note.pitch))
+            yield step, label, note.velocity, micro
+
+
+def _iter_wav(path: Path) -> Iterator[tuple[int, str, int, int]]:
+    """Return onset positions from a WAV file using librosa."""
+
+    try:
+        import librosa
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("WAV support requires librosa") from exc
+
+    y, sr = librosa.load(path, sr=None, mono=True)
+    tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
+    bpm = float(tempo) if tempo else 120.0
+    sec_per_beat = 60.0 / bpm
+    onsets = librosa.onset.onset_detect(y=y, sr=sr, units="time")
+    for t in onsets:
+        beat = t / sec_per_beat
+        step = int(round(beat * (RESOLUTION / 4)))
+        micro = 0
+        yield step, "perc", 100, micro
+
+
+def _load_events(
+    loop_dir: Path, exts: Sequence[str]
+) -> tuple[list[list[State]], dict[str, float], dict[str, Counter[int]], dict[str, Counter[int]]]:
+    events: list[list[State]] = []
+    vel_map: dict[str, list[int]] = defaultdict(list)
+    micro_map: dict[str, list[int]] = defaultdict(list)
+
+    normalized = {e.replace("midi", "mid") for e in exts}
+    for p in loop_dir.iterdir():
+        suf = p.suffix.lower().lstrip(".")
+        suf = "mid" if suf in {"mid", "midi"} else suf
+        if suf not in normalized:
+            continue
+        seq: list[State] = []
+        if p.suffix.lower() in {".mid", ".midi"}:
+            iterator = _iter_midi(p)
+        else:
+            iterator = _iter_wav(p)
+        for step, lbl, vel, micro in iterator:
+            seq.append(((step % RESOLUTION), lbl))
+            vel_map[lbl].append(vel)
+            micro_map[lbl].append(micro)
+        if seq:
+            events.append(sorted(seq, key=lambda x: x[0]))
+    mean_velocity = {k: sum(v) / len(v) for k, v in vel_map.items() if v}
+    vel_deltas = {
+        k: Counter(int(v - mean_velocity[k]) for v in vals)
+        for k, vals in vel_map.items()
+    }
+    micro_offsets = {k: Counter(vals) for k, vals in micro_map.items()}
+    return events, mean_velocity, vel_deltas, micro_offsets
+
+
+def train(loop_dir: Path, *, ext: str = "midi", order: int | str = "auto") -> Model:
+    """Train an n-gram model from MIDI/WAV loops."""
+
+    exts = [e.strip().lower() for e in ext.split(",") if e]
+    if order == "auto":
+        n = 3
+    else:
+        n = int(order)
+    seqs, mean_vel, vel_deltas, micro_offsets = _load_events(loop_dir, exts)
+    if not any(seqs):
+        raise ValueError("no events found")
+
+    freq: dict[int, dict[tuple[State, ...], Counter[State]]] = {
+        i: defaultdict(Counter) for i in range(n)
+    }
+    for seq in seqs:
+        for s in seq:
+            freq[0][()][s] += 1
+        for i in range(1, n):
+            for idx in range(len(seq) - i):
+                ctx = tuple(seq[idx : idx + i])
+                nxt = seq[idx + i]
+                freq[i][ctx][nxt] += 1
+
+    prob: dict[int, dict[tuple[State, ...], dict[State, float]]] = {i: {} for i in range(n)}
+    for order_i, ctx_map in freq.items():
+        for ctx, counter in ctx_map.items():
+            total = sum(counter.values())
+            if total == 0:
+                continue
+            v = len(counter)
+            prob[order_i][ctx] = {
+                s: (c + ALPHA) / (total + ALPHA * v) for s, c in counter.items()
+            }
+
+    model: Model = Model(
+        version=VERSION,
+        resolution=RESOLUTION,
+        order=n,
+        freq=freq,
+        prob=prob,
+        mean_velocity=mean_vel,
+        vel_deltas=vel_deltas,
+        micro_offsets=micro_offsets,
+    )
+    return model
+
+
+def save(model: Model, path: Path) -> None:
+    with path.open("wb") as fh:
+        pickle.dump(dict(model), fh)
+
+
+def load(path: Path) -> Model:
+    with path.open("rb") as fh:
+        data = pickle.load(fh)
+    if (
+        data.get("resolution") != RESOLUTION
+        or data.get("version") != VERSION
+    ):
+        raise RuntimeError("incompatible model version")
+    return Model(**data)
+
+
+def _choose(probs: dict[State, float], rng: Random) -> State:
+    states = list(probs.keys())
+    weights = list(probs.values())
+    return rng.choices(states, weights, k=1)[0]
+
+
+def _sample_next(
+    history: Sequence[State],
+    model: Model,
+    rng: Random,
+    *,
+    temperature: float = 1.0,
+    top_k: int | None = None,
+) -> State:
+    n = model["order"]
+    for order in range(min(len(history), n - 1), -1, -1):
+        ctx = tuple(history[-order:])
+        dist = model["prob"].get(order, {}).get(ctx)
+        if dist:
+            break
+    if not dist:
+        dist = model["prob"][0][()]
+    if top_k is not None:
+        dist = dict(sorted(dist.items(), key=lambda x: x[1], reverse=True)[:top_k])
+    if temperature != 1.0:
+        dist = {k: v ** (1.0 / temperature) for k, v in dist.items()}
+        total = sum(dist.values())
+        dist = {k: v / total for k, v in dist.items()}
+    return _choose(dist, rng)
+
+
+def sample(
+    model: Model,
+    *,
+    bars: int = 4,
+    temperature: float = 1.0,
+    top_k: int | None = None,
+    seed: int | None = None,
+) -> list[dict[str, float | str]]:
+    """Generate events using the trained model."""
+
+    rng = Random(seed)
+    events: list[dict[str, float | str]] = []
+    history: list[State] = []
+    for bar in range(bars):
+        next_bin = 0
+        while next_bin < RESOLUTION:
+            state = _sample_next(history, model, rng, temperature=temperature, top_k=top_k)
+            step, lbl = state
+            if step < next_bin:
+                step = next_bin
+            offset_beats = (bar * RESOLUTION + step) / (RESOLUTION / 4)
+            micro_choices = list(model["micro_offsets"].get(lbl, {0: 1}).elements())
+            micro = rng.choice(micro_choices) if micro_choices else 0
+            vel_mean = int(model["mean_velocity"].get(lbl, 100))
+            delta_choices = list(model["vel_deltas"].get(lbl, {0: 1}).elements())
+            vel = int(vel_mean + (rng.choice(delta_choices) if delta_choices else 0))
+            events.append(
+                {
+                    "instrument": lbl,
+                    "offset": offset_beats + micro / PPQ,
+                    "duration": 0.25,
+                    "velocity": max(1, min(127, vel)),
+                }
+            )
+            history.append((step, lbl))
+            if len(history) > model["order"] - 1:
+                history.pop(0)
+            next_bin = step + 1
+    events.sort(key=lambda x: x["offset"])
+    return events
+
+
+def events_to_midi(events: Sequence[dict[str, float | str]]) -> pretty_midi.PrettyMIDI:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    pitch_map = {k: v[1] for k, v in GM_DRUM_MAP.items()}
+    for ev in events:
+        start = float(ev.get("offset", 0.0)) * 0.5  # beat to seconds at 120bpm
+        end = start + float(ev.get("duration", 0.25)) * 0.5
+        pitch = pitch_map.get(str(ev.get("instrument")), 36)
+        velocity = int(ev.get("velocity", 100))
+        inst.notes.append(pretty_midi.Note(velocity=velocity, pitch=pitch, start=start, end=end))
+    pm.instruments.append(inst)
+    return pm
+
+
+@click.group()
+def cli() -> None:
+    """Groove sampler commands."""
+
+
+@cli.command()
+@click.argument("loop_dir", type=Path)
+@click.option("--ext", default="wav,midi", help="Comma separated extensions")
+@click.option("--order", default="auto", help="n-gram order or 'auto'")
+@click.option("--out", "out_path", type=Path, default=Path("model.pkl"))
+def train_cmd(loop_dir: Path, ext: str, order: str, out_path: Path) -> None:
+    """Train a model from loops."""
+
+    model = train(loop_dir, ext=ext, order=order)
+    save(model, out_path)
+    click.echo(f"saved model to {out_path}")
+
+
+@cli.command()
+@click.argument("model_path", type=Path)
+@click.option("-l", "--length", default=4, type=int)
+@click.option("--temperature", default=1.0, type=float)
+@click.option("--seed", default=42, type=int)
+def sample_cmd(model_path: Path, length: int, temperature: float, seed: int) -> None:
+    """Generate MIDI from a model."""
+
+    model = load(model_path)
+    ev = sample(model, bars=length, temperature=temperature, seed=seed)
+    pm = events_to_midi(ev)
+    buf = io.BytesIO()
+    pm.write(buf)
+    sys.stdout.buffer.write(buf.getvalue())
+
+
+def main(argv: Sequence[str] | None = None) -> None:  # pragma: no cover
+    cli.main(args=list(argv) if argv is not None else None, standalone_mode=False)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- normalize steps and improve WAV handling in groove sampler
- enforce non-empty training data
- clamp sampled event offsets when generating drums
- expose groove sampler docs in navigation
- add regression tests for multi-bar loops
- ensure step offsets stay within a bar and validate model metadata
- include "perc" label mapping
- lazily import groove sampler and handle missing deps

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini utilities/groove_sampler_ngram.py modular_composer/cli.py generator/drum_generator.py tests/test_groove_sampler.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d903df5b48328a4cbbce3ea3807b6