### PR TITLE
Implement Aux-Conditioned Groove Sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,17 @@ modcompose groove train data/loops --ext midi --out model.pkl
 modcompose groove sample model.pkl -l 4 --temperature 0.8 --seed 42 > groove.mid
 ```
 
+Groove Sampler **v1.1** supports auxiliary conditioning on section type,
+heatmap bin and intensity bucket. Provide a JSON map at train time and pass
+`--cond` when sampling:
+
+```bash
+modcompose groove train data/loops --aux aux.json
+modcompose groove sample model.pkl --cond '{"section":"chorus","intensity":"high"}' > groove.mid
+```
+
+If you omit `--aux` the model behaves like version 1.0.
+
 ### Groove Sampler v2
 
 Build and sample using the optimized model:

--- a/docs/groove_sampler.md
+++ b/docs/groove_sampler.md
@@ -18,3 +18,19 @@ Generate a four bar MIDI groove:
 ```bash
 modcompose groove sample model.pkl -l 4 --temperature 0.8 --seed 42 > out.mid
 ```
+
+## Aux-feature training / sampling
+
+You can condition groove generation on section type, vocal heatmap bin and
+intensity bucket. Provide a JSON file mapping each loop filename to auxiliary
+data when training and use `--cond` at sampling time:
+
+```bash
+modcompose groove train loops/ --aux aux.json
+modcompose groove sample model.pkl --cond '{"section":"chorus","intensity":"high"}' > out.mid
+```
+
+### Backward compatibility
+
+If you omit the `--aux` option during training, the sampler behaves exactly as
+in version 1.0 and ignores auxiliary conditions.

--- a/tests/test_drum_articulations.py
+++ b/tests/test_drum_articulations.py
@@ -37,6 +37,7 @@ def test_hihat_articulations(tmp_path: Path):
         0.5,
         drum.global_ts,
         {},
+        None,
     )
     pitches = {n.pitch.midi for n in part.flatten().notes}
     expected = {
@@ -65,6 +66,7 @@ def test_hihat_edge_pedal(tmp_path: Path):
         0.5,
         drum.global_ts,
         {},
+        None,
     )
     notes = sorted(part.flatten().notes, key=lambda n: n.offset)
     assert len(notes) == 2
@@ -93,6 +95,7 @@ def test_velocity_random_walk(tmp_path: Path):
             0.5,
             drum.global_ts,
             {},
+            None,
         )
     notes = list(part.flatten().notes)
     assert len({n.volume.velocity for n in notes}) >= 3
@@ -126,6 +129,7 @@ def test_brush_override_scaling(tmp_path: Path):
         0.5,
         drum.global_ts,
         {},
+        None,
     )
     velocities = [n.volume.velocity for n in part.flatten().notes]
     assert velocities and all(v < o for v, o in zip(velocities, orig_vel))
@@ -150,6 +154,7 @@ def test_intro_ride_notes(tmp_path: Path):
         0.5,
         drum.global_ts,
         {},
+        None,
     )
     notes = list(part.flatten().notes)
     assert notes
@@ -174,6 +179,7 @@ def test_drag_ruff(tmp_path: Path):
         0.5,
         drum.global_ts,
         {},
+        None,
     )
     notes = list(part.flatten().notes)
     assert len(notes) == 7

--- a/tests/test_velocity_curve.py
+++ b/tests/test_velocity_curve.py
@@ -42,6 +42,7 @@ def test_velocity_curve_scaling(tmp_path: Path):
         0.5,
         gen.global_ts,
         {},
+        None,
         1.0,
         [0.5, 0.75, 1.0],
     )


### PR DESCRIPTION
## Summary
- add auxiliary conditioning to `groove_sampler_ngram`
- allow CLI to pass aux map and sampling conditions
- integrate aux conditions in `DrumGenerator`
- extend tests to cover aux-based sampling
- document aux-feature training and sampling
- improve robustness of hash collisions and fallback
- fix tests after `_apply_pattern` signature change
- document GrooveSampler v1.1 usage in README
- fix auxiliary sampler test labels

## Testing
- `ruff check .`
- `mypy --strict`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685df871ae8c8328b762581532764052