### PR TITLE
Fix old model loading after aux dims removal

### DIFF
--- a/docs/groove_sampler.md
+++ b/docs/groove_sampler.md
@@ -34,3 +34,6 @@ modcompose groove sample model.pkl --cond '{"section":"chorus","intensity":"high
 
 If you omit the `--aux` option during training, the sampler behaves exactly as
 in version 1.0 and ignores auxiliary conditions.
+
+Models generated prior to commit 608fdda no longer include the
+deprecated `aux_dims` field and should be retrained.


### PR DESCRIPTION
## Summary
- pop legacy `aux_dims` in `load()`
- warn in documentation that pre-608fdda models should be retrained

## Testing
- `ruff check utilities/groove_sampler_ngram.py`
- `mypy --strict utilities/groove_sampler_ngram.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e29ae1f14832888c1ce55ce9d8fa1