### PR TITLE
Implement generate_bar API and integrate n-gram sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,35 @@ Add subtle velocity and timing variation using the trained histograms:
 modcompose groove sample model.pkl -l 8 --humanize vel,micro > groove.mid
 ```
 
+### Sampling API
+
+The helper ``generate_bar`` yields one bar at a time and also returns the
+updated n‑gram history:
+
+```python
+from utilities import groove_sampler_ngram as gs
+model = gs.load(Path("model.pkl"))
+events, history = gs.generate_bar(None, model, temperature=0.0, top_k=1, rng=random.Random(0))
+```
+
+You may constrain choices to the top ``k`` states and condition on auxiliary
+labels such as section or intensity:
+
+```python
+events, history = gs.generate_bar(
+    history,
+    model,
+    temperature=0.8,
+    top_k=3,
+    cond={"section": "chorus", "intensity": "high"},
+    rng=random.Random(42),
+)
+```
+
+Passing ``temperature=0`` selects the most probable state deterministically.
+Use ``--humanize vel,micro`` when sampling from the CLI to apply velocity and
+micro‑timing variation.
+
 ### DAW Usage
 
 Import the resulting ``groove.mid`` into your DAW (Ableton, Logic, etc.).

--- a/tests/test_drum_generator_ngram_integration.py
+++ b/tests/test_drum_generator_ngram_integration.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+import pretty_midi
+
+from generator.drum_generator import DrumGenerator
+from utilities import groove_sampler_ngram
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    for i in range(4):
+        start = i * 0.25
+        inst.notes.append(
+            pretty_midi.Note(velocity=100, pitch=36, start=start, end=start + 0.05)
+        )
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def _cfg(tmp_path: Path) -> dict:
+    heatmap = [{"grid_index": i, "count": 0} for i in range(16)]
+    hp = tmp_path / "heatmap.json"
+    with hp.open("w") as f:
+        json.dump(heatmap, f)
+    return {
+        "vocal_midi_path_for_drums": "",
+        "heatmap_json_path_for_drums": str(hp),
+        "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
+        "global_settings": {"rng_seed": 0},
+    }
+
+
+def test_drum_generator_ngram_integration(tmp_path: Path) -> None:
+    for i in range(2):
+        _make_loop(tmp_path / f"{i}.mid")
+    model = groove_sampler_ngram.train(tmp_path, order=2)
+    cfg = _cfg(tmp_path)
+    gen = DrumGenerator(main_cfg=cfg, part_name="drums", part_parameters={})
+    gen.groove_model = model
+    section = {"absolute_offset": 0.0, "q_length": 16.0, "part_params": {}}
+    part = gen.compose(section_data=section)
+    assert len(list(part.flatten().notes)) >= 1

--- a/tests/test_empty_aux_backoff.py
+++ b/tests/test_empty_aux_backoff.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import pretty_midi
+
+from utilities import groove_sampler_ngram as gs
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    inst.notes.append(pretty_midi.Note(velocity=100, pitch=36, start=0.0, end=0.1))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_unknown_aux_fallback(tmp_path: Path) -> None:
+    _make_loop(tmp_path / "verse.mid")
+    aux_map = {"verse.mid": {"section": "verse", "heat_bin": 0, "intensity": "mid"}}
+    model = gs.train(tmp_path, aux_map=aux_map, order=1)
+    events = gs.sample(model, bars=1, cond={"section": "bridge"})
+    assert events
+

--- a/tests/test_missing_prob_message.py
+++ b/tests/test_missing_prob_message.py
@@ -1,0 +1,25 @@
+import random
+from pathlib import Path
+import pretty_midi
+import pytest
+
+from utilities import groove_sampler_ngram as gs
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    inst.notes.append(pretty_midi.Note(velocity=100, pitch=36, start=0.0, end=0.1))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_error_message_contains_context(tmp_path: Path) -> None:
+    _make_loop(tmp_path / "a.mid")
+    model = gs.train(tmp_path, order=1)
+    model["prob"][0] = {}
+    with pytest.raises(RuntimeError) as exc:
+        gs.generate_bar(None, model, rng=random.Random(0))
+    msg = str(exc.value)
+    assert "context" in msg and "aux" in msg
+

--- a/tests/test_sample_aux_fallback.py
+++ b/tests/test_sample_aux_fallback.py
@@ -1,0 +1,37 @@
+import warnings
+import random
+from pathlib import Path
+
+import pretty_midi
+
+from utilities import groove_sampler_ngram as gs
+
+
+def _make_loop(path: Path, pitch: int = 36) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    inst.notes.append(pretty_midi.Note(velocity=100, pitch=pitch, start=0.0, end=0.1))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_generate_bar_aux_fallback(tmp_path: Path) -> None:
+    _make_loop(tmp_path / "verse.mid")
+    aux_map = {"verse.mid": {"section": "verse", "heat_bin": 0, "intensity": "mid"}}
+    model = gs.train(tmp_path, aux_map=aux_map, order=1)
+    with warnings.catch_warnings(record=True) as rec:
+        ev, _ = gs.generate_bar(None, model, cond={"section": "bridge"})
+    assert ev
+    assert any("unknown aux" in str(w.message).lower() for w in rec)
+
+
+def test_topk_temp_zero_equivalent(tmp_path: Path) -> None:
+    for i in range(2):
+        _make_loop(tmp_path / f"{i}.mid", pitch=36 + i)
+    model = gs.train(tmp_path, order=2)
+    hist: list[gs.State] = []
+    ev_a, _ = gs.generate_bar(hist, model, temperature=0.0, top_k=1, rng=random.Random(0))
+    ev_b, _ = gs.generate_bar(hist, model, temperature=0.0, rng=random.Random(0))
+    a_first = (round(ev_a[0]["offset"] * 4), ev_a[0]["instrument"])
+    b_first = (round(ev_b[0]["offset"] * 4), ev_b[0]["instrument"])
+    assert a_first == b_first

--- a/tests/test_sampler_cli_humanize.py
+++ b/tests/test_sampler_cli_humanize.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from click.testing import CliRunner
+import io
+import pretty_midi
+
+from utilities import groove_sampler_ngram as gs
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    for i in range(4):
+        start = i * 0.25
+        vel = 90 + i * 5
+        inst.notes.append(pretty_midi.Note(velocity=vel, pitch=36, start=start, end=start + 0.05))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_cli_humanize(tmp_path: Path) -> None:
+    _make_loop(tmp_path / "a.mid")
+    model = gs.train(tmp_path, order=1)
+    gs.save(model, tmp_path / "m.pkl")
+    runner = CliRunner()
+    res = runner.invoke(
+        gs.cli,
+        ["sample", str(tmp_path / "m.pkl"), "-l", "1", "--seed", "0", "--humanize", "vel,micro"],
+    )
+    assert res.exit_code == 0
+    pm = pretty_midi.PrettyMIDI(io.BytesIO(res.stdout_bytes))
+    vels = [n.velocity for n in pm.instruments[0].notes]
+    assert max(vels) != min(vels)
+    step_ticks = gs.PPQ // 4
+    for n in pm.instruments[0].notes:
+        start_beats = n.start / 0.5
+        ticks = round(start_beats * gs.PPQ)
+        step = round(start_beats * 4)
+        micro = ticks - step * step_ticks
+        assert -45 <= micro <= 45
+

--- a/tests/test_sampler_generate_bar.py
+++ b/tests/test_sampler_generate_bar.py
@@ -1,0 +1,51 @@
+import random
+from pathlib import Path
+
+import pretty_midi
+
+from utilities import groove_sampler_ngram
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    for i in range(4):
+        start = i * 0.25
+        inst.notes.append(
+            pretty_midi.Note(velocity=100, pitch=36, start=start, end=start + 0.05)
+        )
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_generate_bar_history_and_deterministic(tmp_path: Path) -> None:
+    for i in range(2):
+        _make_loop(tmp_path / f"{i}.mid")
+    model = groove_sampler_ngram.train(tmp_path, order=2)
+    history: list[groove_sampler_ngram.State] = []
+    events1, history = groove_sampler_ngram.generate_bar(history, model, rng=random.Random(0))
+    assert events1
+    assert len(history) <= model["order"] - 1
+    events_a, _ = groove_sampler_ngram.generate_bar(history.copy(), model, temperature=0, rng=random.Random(1))
+    events_b, _ = groove_sampler_ngram.generate_bar(history.copy(), model, temperature=0, rng=random.Random(2))
+    first_a = (int(round(events_a[0]["offset"] * 4)), events_a[0]["instrument"])
+    first_b = (int(round(events_b[0]["offset"] * 4)), events_b[0]["instrument"])
+    assert first_a == first_b
+
+
+def test_gaussian_fallback(tmp_path: Path) -> None:
+    _make_loop(tmp_path / "a.mid")
+    model = groove_sampler_ngram.train(tmp_path, order=1)
+    model["micro_offsets"] = {}
+    events, _ = groove_sampler_ngram.generate_bar(None, model, humanize_micro=True, rng=random.Random(0))
+    assert events
+    step_ticks = groove_sampler_ngram.PPQ // 4
+    found = False
+    for ev in events:
+        off_ticks = round(ev["offset"] * groove_sampler_ngram.PPQ)
+        step = round(ev["offset"] * 4)
+        micro = off_ticks - step * step_ticks
+        if micro != 0:
+            assert -45 <= micro <= 45
+            found = True
+    assert found

--- a/tests/test_sampler_humanize_flag.py
+++ b/tests/test_sampler_humanize_flag.py
@@ -1,0 +1,29 @@
+import random
+from pathlib import Path
+
+import pretty_midi
+
+from utilities import groove_sampler_ngram as gs
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    for i in range(4):
+        start = i * 0.25
+        inst.notes.append(
+            pretty_midi.Note(velocity=100, pitch=36, start=start, end=start + 0.05)
+        )
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_sampler_humanize_flag(tmp_path: Path) -> None:
+    _make_loop(tmp_path / "a.mid")
+    model = gs.train(tmp_path, order=1)
+    ev = gs.sample(model, bars=1, seed=0, humanize_vel=True, humanize_micro=True)
+    assert ev
+    for e in ev:
+        assert 1 <= e["velocity"] <= 127
+        micro = round(e["offset"] * gs.PPQ) % (gs.PPQ // 4)
+        assert -45 <= micro <= 45


### PR DESCRIPTION
## Summary
- streamline `sample` using `generate_bar`
- validate drum generator history length
- surface context in n-gram fallback errors
- document humanize flags and deterministic call in README
- add CLI and aux fallback tests for edge cases

## Testing
- `ruff check .`
- `mypy --strict`
- `pytest tests/test_sampler_generate_bar.py tests/test_drum_generator_ngram_integration.py tests/test_sampler_humanize_flag.py tests/test_sample_aux_fallback.py tests/test_sampler_cli_humanize.py tests/test_empty_aux_backoff.py tests/test_missing_prob_message.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685f4775ab1883288db9857dfc971fab