### PR TITLE
Implement drum event extras and CLI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ modcompose groove sample model.pkl -l 1 --play
 ```
 List auxiliary tuples without generating MIDI:
 ```bash
-modcompose groove sample model.pkl -l 0 --list-aux
+modcompose groove sample model.pkl --list-aux
 ```
 
 If no MIDI player is detected a warning is emitted and the raw MIDI is written to ``stdout``.

--- a/tests/helpers/events.py
+++ b/tests/helpers/events.py
@@ -1,9 +1,9 @@
-from typing import Any, cast
+from typing import Any
 
 from utilities.groove_sampler_ngram import Event
 
 
-def make_event(
+def ev(
     *,
     instrument: str,
     offset: float,
@@ -12,11 +12,14 @@ def make_event(
     **extra: Any,
 ) -> Event:
     """Create an ``Event`` with defaults and allow extra keys."""
-    data: dict[str, Any] = {
+    data: Event = {
         "instrument": instrument,
         "offset": float(offset),
         "duration": float(duration),
         "velocity": int(velocity),
     }
     data.update(extra)
-    return cast(Event, data)
+    return data
+
+
+make_event = ev

--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -22,6 +22,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from random import Random
 from typing import Any, TypedDict
+from typing_extensions import Required
 
 import click
 import numpy as np
@@ -48,13 +49,13 @@ State = tuple[int, str]
 HashKey = tuple[State | int, ...]
 
 
-class Event(TypedDict):
+class Event(TypedDict, total=False):
     """Drum event definition."""
 
-    instrument: str
-    offset: float
-    duration: float
-    velocity: int
+    instrument: Required[str]
+    offset: Required[float]
+    duration: Required[float]
+    velocity: Required[int]
 
 
 def init_history_from_events(events: Sequence[Event], order: int = 3) -> list[State]:


### PR DESCRIPTION
## Summary
- allow optional fields in `Event` TypedDict
- provide helper `ev` for test events without casts
- support platform mocking in preview fallback tests
- document `--list-aux` usage in README

## Testing
- `ruff check .`
- `mypy --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ada75e208328b897d08740bf512f