### PR TITLE
Finish integration tasks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.gif binary
+*.mid binary

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ modcompose groove sample model.pkl -l 1 --play
 ```
 List auxiliary tuples without generating MIDI:
 ```bash
-modcompose groove sample model.pkl --list-aux
+modcompose groove sample model.pkl --list-aux  # alias: --aux-list
 ```
 
 If no MIDI player is detected a warning is emitted and the raw MIDI is written to ``stdout``.

--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -1245,7 +1245,7 @@ class DrumGenerator(BasePartGenerator):
                 velocity_scale = 1.2 if max_bin_val > self.heatmap_threshold else 1.0
                 self._apply_pattern(
                     part,
-                    cast(list[GrooveEvent], pattern_to_use_for_iteration),
+                    list(pattern_to_use_for_iteration),
                     bar_start_abs_offset,
                     current_pattern_iteration_ql,
                     base_vel,
@@ -2185,7 +2185,7 @@ class DrumGenerator(BasePartGenerator):
         self.current_bpm = self._current_bpm(0.0)
         self.kick_offsets.clear()
         events = [
-            cast(GrooveEvent, {"instrument": "kick", "offset": float(b)})
+            {"instrument": "kick", "offset": float(b)}
             for b in range(int(length_beats))
         ]
         self._apply_pattern(

--- a/tests/test_invalid_step_warning.py
+++ b/tests/test_invalid_step_warning.py
@@ -1,33 +1,41 @@
 import random
 from pathlib import Path
+import warnings
+
 import pretty_midi
 import pytest
 
 from utilities import groove_sampler_ngram as gs
 
 
-def _loop(p: Path) -> None:
+def _make_loop(path: Path) -> None:
     pm = pretty_midi.PrettyMIDI(initial_tempo=120)
     inst = pretty_midi.Instrument(program=0, is_drum=True)
     inst.notes.append(pretty_midi.Note(velocity=100, pitch=36, start=0.0, end=0.1))
     pm.instruments.append(inst)
-    pm.write(str(p))
+    pm.write(str(path))
 
 
-def test_invalid_step_warning(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    _loop(tmp_path / "a.mid")
-    model = gs.train(tmp_path, order=2)
-    called = False
+def test_invalid_step_warning(tmp_path: Path, monkeypatch) -> None:
+    _make_loop(tmp_path / "a.mid")
+    model = gs.train(tmp_path, order=1)
 
-    def fake(*args, **kwargs):
-        nonlocal called
-        if not called:
-            called = True
-            return gs.RESOLUTION + 5, "kick"
+    orig = gs._sample_next
+
+    def fake_sample_next(history, model_arg, rng, **kwargs):
+        if not hasattr(fake_sample_next, "called"):
+            fake_sample_next.called = True
+            return gs.RESOLUTION + 1, "kick"
         return 0, "kick"
 
-    monkeypatch.setattr(gs, "_sample_next", fake)
-    with pytest.warns(RuntimeWarning):
-        ev, hist = gs.generate_bar(None, model, rng=random.Random(0))
-    assert all(e["offset"] >= 0 for e in ev)
-    assert hist and hist[0][0] < gs.RESOLUTION
+    monkeypatch.setattr(gs, "_sample_next", fake_sample_next)
+
+    with warnings.catch_warnings(record=True) as rec:
+        events, history = gs.generate_bar([], model, rng=random.Random(0))
+
+    assert len(rec) == 1
+    assert issubclass(rec[0].category, RuntimeWarning)
+    assert all(0 <= e["offset"] < 4 for e in events)
+    assert all(0 <= s < gs.RESOLUTION for s, _ in history)
+
+    monkeypatch.setattr(gs, "_sample_next", orig)

--- a/tests/test_preview_fallback.py
+++ b/tests/test_preview_fallback.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pretty_midi
 from click.testing import CliRunner
+import logging
 
 from utilities import cli_playback
 from utilities import groove_sampler_ngram as gs
@@ -18,14 +19,16 @@ def _loop(p: Path) -> None:
 
 
 @pytest.mark.parametrize("platform", ["linux", "darwin", "win32"])
-def test_cli_preview_fallback(tmp_path: Path, monkeypatch, platform: str) -> None:
+def test_cli_preview_fallback(tmp_path: Path, monkeypatch, platform: str, caplog) -> None:
     _loop(tmp_path / "a.mid")
     model = gs.train(tmp_path, order=1)
     gs.save(model, tmp_path / "m.pkl")
     monkeypatch.setattr(cli_playback, "find_player", lambda: None)
     monkeypatch.setattr(sys, "platform", platform, raising=False)
     runner = CliRunner()
-    res = runner.invoke(gs.cli, ["sample", str(tmp_path / "m.pkl"), "-l", "1", "--play"])
+    with caplog.at_level(logging.WARNING):
+        res = runner.invoke(gs.cli, ["sample", str(tmp_path / "m.pkl"), "-l", "1", "--play"])
     assert res.exit_code == 0
     assert len(res.stdout_bytes) > 0
+    assert "no MIDI player found" in caplog.text
 

--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -1051,7 +1051,13 @@ def train_cmd(
 
 @cli.command()
 @click.argument("model_path", type=Path)
-@click.option("--list-aux", is_flag=True, help="List known aux tuples and exit")
+@click.option(
+    "--list-aux",
+    "--aux-list",
+    "list_aux",
+    is_flag=True,
+    help="List known aux tuples and exit",
+)
 @click.option("-l", "--length", default=4, type=int)
 @click.option("--temperature", default=1.0, type=float)
 @click.option("--seed", default=42, type=int)

--- a/utilities/peak_synchroniser.py
+++ b/utilities/peak_synchroniser.py
@@ -36,16 +36,13 @@ class PeakSynchroniser:
             ev_off = PeakSynchroniser._quantize(float(ev.get("offset", 0.0)))
             if abs(ev_off - q_off) <= 1e-6:
                 if priority.get(instrument, 0) > priority.get(ev.get("instrument", ""), 0):
-                    events[idx] = cast(
-                        Event,
-                        {
-                            "instrument": instrument,
-                            "offset": q_off,
-                            "duration": ev.get("duration", 0.25),
-                        },
-                    )
+                    events[idx] = {
+                        "instrument": instrument,
+                        "offset": q_off,
+                        "duration": ev.get("duration", 0.25),
+                    }
                 return
-        events.append(cast(Event, {"instrument": instrument, "offset": q_off, "duration": 0.25}))
+        events.append({"instrument": instrument, "offset": q_off, "duration": 0.25})
 
     @staticmethod
     def sync_events(


### PR DESCRIPTION
## Summary
- add `--aux-list` alias for listing aux tuples
- declare MIDI files as binary in `.gitattributes`
- drop cast calls from drum generator and peak synchroniser
- capture missing player warnings in preview fallback test
- test invalid-step warnings in the sampler

## Testing
- `ruff check .`
- `mypy --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ba7e790883289467c04a948578ed