### PR TITLE
Add histogram-based groove humanization

### DIFF
--- a/tests/test_groove_sampler_humanize.py
+++ b/tests/test_groove_sampler_humanize.py
@@ -1,0 +1,40 @@
+import statistics
+from pathlib import Path
+
+import pretty_midi
+
+from utilities import groove_sampler_ngram as gs
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    pattern = [
+        (90, -10),
+        (100, 0),
+        (110, 10),
+        (100, 0),
+    ]
+    for i, (vel, micro) in enumerate(pattern):
+        start = i * 0.25 + micro / gs.PPQ
+        inst.notes.append(
+            pretty_midi.Note(velocity=vel, pitch=36, start=start, end=start + 0.05)
+        )
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_humanize_variance(tmp_path: Path) -> None:
+    _make_loop(tmp_path / "a.mid")
+    model = gs.train(tmp_path, order=1)
+    ev = gs.sample(model, bars=8, seed=0, humanize_vel=True, humanize_micro=True)
+    assert len(ev) >= 32
+    vels = [e["velocity"] for e in ev]
+    micros = []
+    step_ticks = gs.PPQ // 4
+    for e in ev:
+        off_ticks = round(e["offset"] * gs.PPQ)
+        step = round(e["offset"] * 4)
+        micros.append(off_ticks - step * step_ticks)
+    assert statistics.pstdev(vels) > 0
+    assert statistics.pstdev(micros) > 0

--- a/tests/test_humanize_clamp.py
+++ b/tests/test_humanize_clamp.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-import json
+
 import pretty_midi
+
 from utilities import groove_sampler_ngram as gs
 
 
@@ -29,5 +30,5 @@ def test_humanize_ranges(tmp_path: Path) -> None:
     for e in ev:
         assert 1 <= int(e["velocity"]) <= 127
         micro = _micro_from_offset(float(e["offset"]))
-        assert abs(micro) <= 45
+        assert abs(micro) <= 30
 

--- a/tests/test_sampler_cli_humanize.py
+++ b/tests/test_sampler_cli_humanize.py
@@ -1,7 +1,8 @@
-from pathlib import Path
-from click.testing import CliRunner
 import io
+from pathlib import Path
+
 import pretty_midi
+from click.testing import CliRunner
 
 from utilities import groove_sampler_ngram as gs
 
@@ -36,5 +37,5 @@ def test_cli_humanize(tmp_path: Path) -> None:
         ticks = round(start_beats * gs.PPQ)
         step = round(start_beats * 4)
         micro = ticks - step * step_ticks
-        assert -45 <= micro <= 45
+        assert -30 <= micro <= 30
 

--- a/tests/test_sampler_generate_bar.py
+++ b/tests/test_sampler_generate_bar.py
@@ -26,26 +26,27 @@ def test_generate_bar_history_and_deterministic(tmp_path: Path) -> None:
     events1, history = groove_sampler_ngram.generate_bar(history, model, rng=random.Random(0))
     assert events1
     assert len(history) <= model["order"] - 1
-    events_a, _ = groove_sampler_ngram.generate_bar(history.copy(), model, temperature=0, rng=random.Random(1))
-    events_b, _ = groove_sampler_ngram.generate_bar(history.copy(), model, temperature=0, rng=random.Random(2))
+    events_a, _ = groove_sampler_ngram.generate_bar(
+        history.copy(), model, temperature=0, rng=random.Random(1)
+    )
+    events_b, _ = groove_sampler_ngram.generate_bar(
+        history.copy(), model, temperature=0, rng=random.Random(2)
+    )
     first_a = (int(round(events_a[0]["offset"] * 4)), events_a[0]["instrument"])
     first_b = (int(round(events_b[0]["offset"] * 4)), events_b[0]["instrument"])
     assert first_a == first_b
 
 
-def test_gaussian_fallback(tmp_path: Path) -> None:
+def test_zero_fallback_when_no_histogram(tmp_path: Path) -> None:
     _make_loop(tmp_path / "a.mid")
     model = groove_sampler_ngram.train(tmp_path, order=1)
     model["micro_offsets"] = {}
-    events, _ = groove_sampler_ngram.generate_bar(None, model, humanize_micro=True, rng=random.Random(0))
+    events, _ = groove_sampler_ngram.generate_bar(
+        None, model, humanize_micro=True, rng=random.Random(0)
+    )
     assert events
-    step_ticks = groove_sampler_ngram.PPQ // 4
-    found = False
     for ev in events:
         off_ticks = round(ev["offset"] * groove_sampler_ngram.PPQ)
         step = round(ev["offset"] * 4)
-        micro = off_ticks - step * step_ticks
-        if micro != 0:
-            assert -45 <= micro <= 45
-            found = True
-    assert found
+        micro = off_ticks - step * (groove_sampler_ngram.PPQ // 4)
+        assert micro == 0

--- a/tests/test_sampler_humanize_flag.py
+++ b/tests/test_sampler_humanize_flag.py
@@ -1,4 +1,3 @@
-import random
 from pathlib import Path
 
 import pretty_midi
@@ -26,4 +25,4 @@ def test_sampler_humanize_flag(tmp_path: Path) -> None:
     for e in ev:
         assert 1 <= e["velocity"] <= 127
         micro = round(e["offset"] * gs.PPQ) % (gs.PPQ // 4)
-        assert -45 <= micro <= 45
+        assert -30 <= micro <= 30

--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -14,7 +14,6 @@ import sys
 import tempfile
 import time
 import warnings
-import weakref
 from collections import Counter, OrderedDict, defaultdict
 from collections.abc import Sequence
 from pathlib import Path
@@ -929,7 +928,7 @@ def generate_bar(
         for k, c in model.get("vel_deltas", {}).items()
     }
     micro_bounds = {
-        k: min(float(np.percentile(np.abs(list(c.elements())), 95)), 45)
+        k: min(float(np.percentile(np.abs(list(c.elements())), 95)), 30)
         if list(c.elements())
         else 0.0
         for k, c in model.get("micro_offsets", {}).items()
@@ -960,11 +959,10 @@ def generate_bar(
             choices = list(model["micro_offsets"].get(lbl, Counter()).elements())
             if choices:
                 micro = int(rand.choice(choices))
-                limit = micro_bounds.get(lbl, 45)
+                limit = micro_bounds.get(lbl, 30)
                 micro = max(-limit, min(limit, micro))
             else:
-                micro = int(rand.gauss(0.0, 12.0))
-                micro = max(-45, min(45, micro))
+                micro = 0
         vel_mean = int(model["mean_velocity"].get(lbl, 100))
         vel = vel_mean
         if humanize_vel:


### PR DESCRIPTION
## Summary
- update groove sampler to clamp micro swing to ±30 ticks
- remove Gaussian fallback and use 0 when no micro histogram
- test drum humanization via CLI and API
- check fallback when histogram is empty
- ensure histogram sampling shows variance

## Testing
- `ruff check tests/test_groove_sampler_humanize.py utilities/groove_sampler_ngram.py tests/test_humanize_clamp.py tests/test_sampler_cli_humanize.py tests/test_sampler_generate_bar.py tests/test_sampler_humanize_flag.py`
- `mypy utilities/groove_sampler_ngram.py tests/test_groove_sampler_humanize.py tests/test_humanize_clamp.py tests/test_sampler_cli_humanize.py tests/test_sampler_generate_bar.py tests/test_sampler_humanize_flag.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861847a878083289438943c1adaa3e7