### PR TITLE
Add public groove generate_bar flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,33 +381,33 @@ modcompose groove sample model.pkl -l 8 --humanize vel,micro > groove.mid
 
 ### Sampling API
 
-The helper ``generate_bar`` yields one bar at a time and also returns the
-updated n‑gram history:
+The helper ``generate_bar`` yields one bar at a time and updates the history
+list in-place:
 
 ```python
 from utilities import groove_sampler_ngram as gs
 model = gs.load(Path("model.pkl"))
-events, history = gs.generate_bar(None, model, temperature=0.0, top_k=1, rng=random.Random(0))
+hist: list[gs.State] = []
+events = gs.generate_bar(hist, model=model, temperature=0.0, top_k=1)
 ```
 
 Deterministic generation can be achieved by setting ``temperature`` to ``0``
 and ``top_k`` to ``1``:
 
 ```python
-events, _ = gs.generate_bar(history, model, temperature=0, top_k=1, rng=random.Random(1))
+events = gs.generate_bar(hist, model=model, temperature=0, top_k=1)
 ```
 
 You may constrain choices to the top ``k`` states and condition on auxiliary
 labels such as section or intensity:
 
 ```python
-events, history = gs.generate_bar(
-    history,
-    model,
+events = gs.generate_bar(
+    hist,
+    model=model,
     temperature=0.8,
     top_k=3,
     cond={"section": "chorus", "intensity": "high"},
-    rng=random.Random(42),
 )
 ```
 

--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -1215,13 +1215,12 @@ class DrumGenerator(BasePartGenerator):
                         if isinstance(tk, (int, str)) and str(tk).isdigit()
                         else None
                     )
-                    pattern_to_use_for_iteration, self._groove_history = groove_sampler_ngram.generate_bar(
+                    pattern_to_use_for_iteration = groove_sampler_ngram.generate_bar(
                         self._groove_history,
-                        self.groove_model,
+                        model=self.groove_model,
                         cond=section_data.get("musical_intent", {}),
                         temperature=float(self.global_settings.get("groove_temperature", 1.0)),
                         top_k=tk_val,
-                        rng=self.rng,
                         humanize_vel=bool(self.global_settings.get("humanize_profile")),
                         humanize_micro=self.groove_strength > 0,
                     )
@@ -1349,15 +1348,14 @@ class DrumGenerator(BasePartGenerator):
             tk = self.global_settings.get("groove_top_k")
             tk_val = int(tk) if isinstance(tk, (int, str)) and str(tk).isdigit() else None
 
-            events, self._groove_history = groove_sampler_ngram.generate_bar(
+            events = groove_sampler_ngram.generate_bar(
                 self._groove_history,
-                model_obj,
+                model=model_obj,
                 temperature=float(self.global_settings.get("groove_temperature", 1.0)),
                 top_k=tk_val,
                 cond=cond,
                 humanize_vel=bool(self.global_settings.get("humanize_profile")),
                 humanize_micro=self.groove_strength > 0,
-                rng=self.rng,
             )
 
         if (

--- a/modular_composer/cli.py
+++ b/modular_composer/cli.py
@@ -24,7 +24,7 @@ try:  # optional dependency
 except Exception:  # pragma: no cover - torch not installed
     groove_sampler_rnn = None  # type: ignore
 from utilities.golden import compare_midi, update_golden
-from utilities.groove_sampler_ngram import Event, State, generate_bar
+from utilities.groove_sampler_ngram import Event, State
 from utilities.groove_sampler_v2 import generate_events, load, save, train  # noqa: F401
 from utilities.peak_synchroniser import PeakSynchroniser
 from utilities.tempo_utils import beat_to_seconds
@@ -156,7 +156,7 @@ def _cmd_render(args: list[str]) -> None:
     ns = ap.parse_args(args)
 
     if ns.spec.suffix.lower() in {".yml", ".yaml"}:
-        import yaml
+        import yaml  # type: ignore
 
         with ns.spec.open("r", encoding="utf-8") as fh:
             spec = yaml.safe_load(fh) or {}
@@ -229,7 +229,9 @@ def _cmd_realtime(args: list[str]) -> None:
                 self.hist.extend(events)
             def next_step(self, *, cond: dict[str, object] | None, rng: random.Random) -> Event:
                 if not self.buf:
-                    self.buf, self.hist = generate_bar(self.hist, m, rng=rng)
+                    self.buf, self.hist = groove_sampler_ngram._generate_bar(
+                        self.hist, m, rng=rng
+                    )
                 return self.buf.pop(0)
         sampler = _WrapN()
 

--- a/tests/test_bar_cache.py
+++ b/tests/test_bar_cache.py
@@ -37,13 +37,13 @@ def test_bar_cache_reduces_lin_prob(tmp_path: Path, monkeypatch) -> None:
         return orig(history, model_arg, rng, **kwargs)
 
     monkeypatch.setattr(gs, "_sample_next", no_cache)
-    gs.generate_bar([], model, rng=random.Random(0))
+    gs.generate_bar([], model=model)
     no_cache_calls = cd.calls
 
     cd2 = CountingCache()
     monkeypatch.setattr(gs, "_lin_prob", cd2, raising=False)
     monkeypatch.setattr(gs, "_sample_next", orig)
-    gs.generate_bar([], model, rng=random.Random(0))
+    gs.generate_bar([], model=model)
     with_cache_calls = cd2.calls
 
     assert with_cache_calls < no_cache_calls

--- a/tests/test_humanize_sampling.py
+++ b/tests/test_humanize_sampling.py
@@ -1,0 +1,41 @@
+import statistics
+from pathlib import Path
+
+import pretty_midi
+
+from utilities import groove_sampler_ngram as gs
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    pattern = [
+        (80, -10),
+        (90, -5),
+        (100, 5),
+        (110, 10),
+    ]
+    for i in range(16):
+        vel, micro = pattern[i % 4]
+        start = i * 0.25 + micro / gs.PPQ
+        inst.notes.append(
+            pretty_midi.Note(velocity=vel, pitch=36, start=start, end=start + 0.05)
+        )
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_humanize_sampling(tmp_path: Path) -> None:
+    _make_loop(tmp_path / "a.mid")
+    model = gs.train(tmp_path, order=1)
+    events = gs.sample(model, bars=16, seed=0, humanize_vel=True, humanize_micro=True)
+    assert len(events) >= 64
+    vels = [e["velocity"] for e in events]
+    micros = []
+    step_ticks = gs.PPQ // 4
+    for e in events:
+        off_ticks = round(e["offset"] * gs.PPQ)
+        step = round(e["offset"] * 4)
+        micros.append(off_ticks - step * step_ticks)
+    assert statistics.pstdev(vels) > 0
+    assert statistics.pstdev(micros) > 0

--- a/tests/test_invalid_step_warning.py
+++ b/tests/test_invalid_step_warning.py
@@ -31,9 +31,9 @@ def test_invalid_step_warning(tmp_path: Path, monkeypatch, caplog) -> None:
 
     prev = [(gs.RESOLUTION * 2, "snare")]
     with caplog.at_level(logging.DEBUG):
-        events, history = gs.generate_bar(prev, model, rng=random.Random(0))
+        events = gs.generate_bar(prev, model=model)
 
     assert "invalid step" in caplog.text
-    assert len(history) == len(prev)
+    assert len(prev) == 1
 
     monkeypatch.setattr(gs, "_sample_next", orig)

--- a/tests/test_missing_prob_message.py
+++ b/tests/test_missing_prob_message.py
@@ -19,7 +19,7 @@ def test_error_message_contains_context(tmp_path: Path) -> None:
     model = gs.train(tmp_path, order=1)
     model["prob"][0] = {}
     with pytest.raises(RuntimeError) as exc:
-        gs.generate_bar(None, model, rng=random.Random(0))
+        gs.generate_bar(None, model=model)
     msg = str(exc.value)
     assert "context" in msg and "aux" in msg
 

--- a/tests/test_ngram_fallback.py
+++ b/tests/test_ngram_fallback.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+import pretty_midi
+
+from generator.drum_generator import DrumGenerator
+from utilities import groove_sampler_ngram as gs
+
+
+def _loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    for i in range(4):
+        inst.notes.append(pretty_midi.Note(velocity=100, pitch=36, start=i * 0.25, end=i * 0.3))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def _cfg(tmp: Path) -> dict:
+    heat = [{"grid_index": i, "count": 0} for i in range(gs.RESOLUTION)]
+    hp = tmp / "heat.json"
+    with hp.open("w") as fh:
+        json.dump(heat, fh)
+    return {
+        "vocal_midi_path_for_drums": "",
+        "heatmap_json_path_for_drums": str(hp),
+        "paths": {"rhythm_library_path": "data/rhythm_library.yml"},
+        "global_settings": {"rng_seed": 0},
+    }
+
+
+def test_ngram_fallback_empty_pattern(tmp_path: Path) -> None:
+    _loop(tmp_path / "loop.mid")
+    model = gs.train(tmp_path, order=1)
+    cfg = _cfg(tmp_path)
+    pattern_lib = {"main": {"pattern": None, "length_beats": 4.0}}
+    gen = DrumGenerator(main_cfg=cfg, part_name="drums", part_parameters=pattern_lib)
+    gen.groove_model = model
+    section = {
+        "absolute_offset": 0.0,
+        "q_length": 4.0,
+        "part_params": {"drums": {"final_style_key_for_render": "main"}},
+        "musical_intent": {"intensity": "mid"},
+    }
+    part = gen.compose(section_data=section)
+    assert len(list(part.flatten().notes)) > 0

--- a/tests/test_sample_aux_fallback.py
+++ b/tests/test_sample_aux_fallback.py
@@ -20,7 +20,7 @@ def test_generate_bar_aux_fallback(tmp_path: Path) -> None:
     aux_map = {"verse.mid": {"section": "verse", "heat_bin": 0, "intensity": "mid"}}
     model = gs.train(tmp_path, aux_map=aux_map, order=1)
     with warnings.catch_warnings(record=True) as rec:
-        ev, _ = gs.generate_bar(None, model, cond={"section": "bridge"})
+        ev = gs.generate_bar(None, model=model, cond={"section": "bridge"})
     assert ev
     assert any("unknown aux" in str(w.message).lower() for w in rec)
 
@@ -29,9 +29,10 @@ def test_topk_temp_zero_equivalent(tmp_path: Path) -> None:
     for i in range(2):
         _make_loop(tmp_path / f"{i}.mid", pitch=36 + i)
     model = gs.train(tmp_path, order=2)
-    hist: list[gs.State] = []
-    ev_a, _ = gs.generate_bar(hist, model, temperature=0.0, top_k=1, rng=random.Random(0))
-    ev_b, _ = gs.generate_bar(hist, model, temperature=0.0, rng=random.Random(0))
+    hist_a: list[gs.State] = []
+    ev_a = gs.generate_bar(hist_a, model=model, temperature=0.0, top_k=1)
+    hist_b: list[gs.State] = []
+    ev_b = gs.generate_bar(hist_b, model=model, temperature=0.0)
     a_first = (round(ev_a[0]["offset"] * 4), ev_a[0]["instrument"])
     b_first = (round(ev_b[0]["offset"] * 4), ev_b[0]["instrument"])
     assert a_first == b_first

--- a/tests/test_sampler_generate_bar.py
+++ b/tests/test_sampler_generate_bar.py
@@ -23,15 +23,13 @@ def test_generate_bar_history_and_deterministic(tmp_path: Path) -> None:
         _make_loop(tmp_path / f"{i}.mid")
     model = groove_sampler_ngram.train(tmp_path, order=2)
     history: list[groove_sampler_ngram.State] = []
-    events1, history = groove_sampler_ngram.generate_bar(history, model, rng=random.Random(0))
+    events1 = groove_sampler_ngram.generate_bar(history, model=model)
     assert events1
     assert len(history) <= model["order"] - 1
-    events_a, _ = groove_sampler_ngram.generate_bar(
-        history.copy(), model, temperature=0, rng=random.Random(1)
-    )
-    events_b, _ = groove_sampler_ngram.generate_bar(
-        history.copy(), model, temperature=0, rng=random.Random(2)
-    )
+    hist_a = history.copy()
+    events_a = groove_sampler_ngram.generate_bar(hist_a, model=model, temperature=0)
+    hist_b = history.copy()
+    events_b = groove_sampler_ngram.generate_bar(hist_b, model=model, temperature=0)
     first_a = (int(round(events_a[0]["offset"] * 4)), events_a[0]["instrument"])
     first_b = (int(round(events_b[0]["offset"] * 4)), events_b[0]["instrument"])
     assert first_a == first_b
@@ -41,12 +39,18 @@ def test_zero_fallback_when_no_histogram(tmp_path: Path) -> None:
     _make_loop(tmp_path / "a.mid")
     model = groove_sampler_ngram.train(tmp_path, order=1)
     model["micro_offsets"] = {}
-    events, _ = groove_sampler_ngram.generate_bar(
-        None, model, humanize_micro=True, rng=random.Random(0)
-    )
+    events = groove_sampler_ngram.generate_bar(None, model=model, humanize_micro=True)
     assert events
     for ev in events:
         off_ticks = round(ev["offset"] * groove_sampler_ngram.PPQ)
         step = round(ev["offset"] * 4)
         micro = off_ticks - step * (groove_sampler_ngram.PPQ // 4)
         assert micro == 0
+
+
+def test_private_generate_bar_smoke(tmp_path: Path) -> None:  # pragma: no cover
+    """private API"""
+    _make_loop(tmp_path / "smoke.mid")
+    model = groove_sampler_ngram.train(tmp_path, order=1)
+    events, history = groove_sampler_ngram._generate_bar(None, model, rng=random.Random(0))
+    assert isinstance(events, list) and isinstance(history, list)

--- a/tests/test_step_guard.py
+++ b/tests/test_step_guard.py
@@ -31,7 +31,7 @@ def test_step_out_of_range_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     orig_res = gs.RESOLUTION
     monkeypatch.setattr(gs, "RESOLUTION", 1)
     with pytest.warns(RuntimeWarning):
-        events, hist = gs.generate_bar(None, model, rng=random.Random(0))
+        events = gs.generate_bar(None, model=model)
     monkeypatch.setattr(gs, "RESOLUTION", orig_res)
     assert len(events) == 1
     assert round(events[0]["offset"] * 4) == 0

--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -856,7 +856,7 @@ def sample(
             pass
 
     for bar in iterable:
-        bar_events, history = generate_bar(
+        bar_events, history = _generate_bar(
             history,
             model,
             temperature=temperature,
@@ -880,7 +880,7 @@ def sample(
     return events
 
 
-def generate_bar(
+def _generate_bar(
     prev_history: list[State] | None,
     model: Model,
     *,
@@ -987,6 +987,35 @@ def generate_bar(
 
     events.sort(key=lambda x: x["offset"])
     return events, history
+
+
+def generate_bar(
+    history: list[State] | None = None,
+    *,
+    model: Model,
+    temperature: float = 1.0,
+    top_k: int | None = None,
+    cond: dict[str, Any] | None = None,
+    humanize_vel: bool = False,
+    humanize_micro: bool = False,
+    use_bar_cache: bool = True,
+) -> list[Event]:
+    """Return a single bar of events using ``sample``.
+
+    ``history`` will be updated in-place when provided.
+    """
+
+    return sample(
+        model,
+        bars=1,
+        temperature=temperature,
+        top_k=top_k,
+        cond=cond,
+        humanize_vel=humanize_vel,
+        humanize_micro=humanize_micro,
+        use_bar_cache=use_bar_cache,
+        history=history,
+    )
 
 
 def events_to_midi(events: Sequence[Event]) -> pretty_midi.PrettyMIDI:


### PR DESCRIPTION
## Summary
- forward humanize parameters through `generate_bar`
- restore humanise in DrumGenerator groove fallback
- adjust tests to call the public API and add a private-API smoke test
- update README for the new history mutation semantics

## Testing
- `ruff check .`
- `mypy --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c60a98f88328b4b18416f0cccbf8