### PR TITLE
Add optional Streamlit GUI and API shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ python -m utilities.groove_sampler_v2 sample model.pkl -l 4 \
 Launch the Streamlit GUI to compare:
 
 ```bash
-streamlit run streamlit_app/visualise_groove.py
+modcompose gui
 ```
 
 ## Vocal Sync

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Install optional extras for the GUI and RNN baseline:
 `pip install -e .[audio,gui,rnn,essentia]`.
 
 For a live comparison of the n-gram and RNN models check out the
-Streamlit GUI:
+Streamlit GUI (run with `modcompose gui`):
+
 
 Real-time playback is available via `modcompose realtime`.

--- a/modular_composer/cli.py
+++ b/modular_composer/cli.py
@@ -156,7 +156,7 @@ def _cmd_render(args: list[str]) -> None:
     ns = ap.parse_args(args)
 
     if ns.spec.suffix.lower() in {".yml", ".yaml"}:
-        import yaml  # type: ignore
+        import yaml
 
         with ns.spec.open("r", encoding="utf-8") as fh:
             spec = yaml.safe_load(fh) or {}
@@ -272,6 +272,13 @@ def _cmd_gm_test(args: list[str]) -> None:
     print("All golden MIDI match.")
 
 
+def _cmd_gui(args: list[str]) -> None:
+    """Launch the Streamlit GUI."""
+    import subprocess
+    script = Path(__file__).resolve().parent.parent / "tools" / "streamlit_gui.py"
+    subprocess.run(["streamlit", "run", str(script), *args], check=True)
+
+
 def main(argv: list[str] | None = None) -> None:
     import sys
 
@@ -292,6 +299,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_realtime(argv[1:])
     elif cmd == "gm-test":
         _cmd_gm_test(argv[1:])
+    elif cmd == "gui":
+        _cmd_gui(argv[1:])
     else:
         cli.main(args=argv, standalone_mode=False)
 

--- a/tests/test_generate_bar_legacy.py
+++ b/tests/test_generate_bar_legacy.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pretty_midi
+import pytest
+
+from utilities import groove_sampler_ngram as gs
+
+
+def _loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    inst.notes.append(pretty_midi.Note(velocity=100, pitch=36, start=0.0, end=0.1))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_generate_bar_legacy(tmp_path: Path) -> None:
+    _loop(tmp_path / "l.mid")
+    model = gs.train(tmp_path, order=1)
+    hist: list[gs.State] = []
+    with pytest.deprecated_call():
+        events, history = gs.generate_bar_legacy(hist, model)
+    assert events
+    assert history is hist

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -1,0 +1,22 @@
+import importlib
+from pathlib import Path
+
+import pretty_midi
+
+from utilities import groove_sampler_ngram
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    inst.notes.append(pretty_midi.Note(velocity=100, pitch=36, start=0.0, end=0.1))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_gui_generate_midi(tmp_path: Path) -> None:
+    _make_loop(tmp_path / "a.mid")
+    model = groove_sampler_ngram.train(tmp_path, order=1)
+    gui = importlib.import_module("tools.streamlit_gui")
+    midi = gui.generate_midi(model, bars=1)
+    assert midi.is_file()

--- a/tools/streamlit_gui.py
+++ b/tools/streamlit_gui.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+
+try:
+    import streamlit as st
+except Exception:  # pragma: no cover - optional dependency
+    st = None
+
+try:
+    import altair as alt
+    import pandas as pd
+except Exception:  # pragma: no cover - altair/pandas optional
+    alt = None
+    pd = None  # type: ignore
+
+from utilities import groove_sampler_ngram as gs
+
+
+def _hit_density(events: Iterable[gs.Event]) -> list[dict[str, object]]:
+    counts: dict[tuple[str, int], int] = {}
+    for ev in events:
+        instr = str(ev["instrument"])
+        step = int(round((float(ev["offset"]) % 4) * (gs.RESOLUTION / 4)))
+        counts[(instr, step)] = counts.get((instr, step), 0) + 1
+    data = [
+        {"instrument": i, "step": s, "count": c}
+        for (i, s), c in sorted(counts.items())
+    ]
+    return data
+
+
+def generate_midi(
+    model: gs.Model,
+    bars: int = 4,
+    *,
+    temperature: float = 1.0,
+    top_k: int | None = None,
+    humanize_vel: bool = False,
+    humanize_micro: bool = False,
+) -> Path:
+    """Return path to a temporary MIDI preview."""
+    history: list[gs.State] = []
+    events: list[gs.Event] = []
+    for bar in range(bars):
+        bar_events = gs.generate_bar(
+            history,
+            model=model,
+            temperature=temperature,
+            top_k=top_k,
+            humanize_vel=humanize_vel,
+            humanize_micro=humanize_micro,
+        )
+        for ev in bar_events:
+            ev["offset"] += bar * 4
+        events.extend(bar_events)
+    pm = gs.events_to_midi(events)
+    tmp = Path(tempfile.mkstemp(suffix=".mid")[1])
+    pm.write(str(tmp))
+    return tmp
+
+
+if st is not None:
+
+    def _main() -> None:  # pragma: no cover - UI
+        st.sidebar.title("Groove Visualiser")
+        model_file = st.sidebar.file_uploader("Model", type=["pkl"])
+        bars = st.sidebar.slider("Bars", 1, 8, 4)
+        temp = st.sidebar.slider("Temperature", 0.0, 2.0, 1.0)
+        topk = st.sidebar.number_input("Top-k", min_value=1, value=8)
+        human_vel = st.sidebar.checkbox("Humanize velocity", value=False)
+        human_micro = st.sidebar.checkbox("Humanize micro", value=False)
+        if st.sidebar.button("Generate") and model_file is not None:
+            path = Path(model_file.name)
+            path.write_bytes(model_file.getbuffer())
+            model = gs.load(path)
+            midi = generate_midi(
+                model,
+                bars,
+                temperature=temp,
+                top_k=int(topk) if topk else None,
+                humanize_vel=human_vel,
+                humanize_micro=human_micro,
+            )
+            st.success("Preview generated")
+            events = gs.sample(model, bars=bars, temperature=temp)
+            data = _hit_density(events)
+            if alt is not None and pd is not None:
+                df = pd.DataFrame(data)
+                chart = alt.Chart(df).mark_rect().encode(
+                    x=alt.X("step:O"),
+                    y=alt.Y("instrument:O"),
+                    color="count:Q",
+                )
+                st.altair_chart(chart, use_container_width=True)
+            else:
+                st.write(data)
+            with open(midi, "rb") as fh:
+                st.download_button("Download MIDI", fh, file_name="preview.mid")
+
+
+    if __name__ == "__main__":  # pragma: no cover - UI
+        _main()
+

--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -1018,6 +1018,20 @@ def generate_bar(
     )
 
 
+def generate_bar_legacy(
+    history: list[State] | None,
+    model: Model,
+    **kw: Any,
+) -> tuple[list[Event], list[State]]:
+    """Return events, history (legacy API)."""
+    warnings.warn(
+        "generate_bar_legacy is deprecated; use generate_bar",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    events = generate_bar(history, model=model, **kw)
+    return events, history if history is not None else []
+
 def events_to_midi(events: Sequence[Event]) -> pretty_midi.PrettyMIDI:
     pm = pretty_midi.PrettyMIDI(initial_tempo=120)
     inst = pretty_midi.Instrument(program=0, is_drum=True)
@@ -1326,6 +1340,7 @@ __all__ = [
     "save",
     "load",
     "sample",
+    "generate_bar_legacy",
     "events_to_midi",
     "profile_train_sample",
     "cli",


### PR DESCRIPTION
## Summary
- add streamlit GUI helper for sampling
- implement CLI wrapper to launch the GUI
- expose deprecated `generate_bar_legacy` wrapper
- document new command (GIF removed)
- fix YAML import annotation

## Testing
- `ruff check tools/streamlit_gui.py modular_composer/cli.py utilities/groove_sampler_ngram.py tests/test_gui_smoke.py tests/test_generate_bar_legacy.py`
- `mypy tools/streamlit_gui.py modular_composer/cli.py utilities/groove_sampler_ngram.py tests/test_gui_smoke.py tests/test_generate_bar_legacy.py`
- `pytest -q tests/test_gui_smoke.py tests/test_generate_bar_legacy.py`

------
https://chatgpt.com/codex/tasks/task_e_6861e1dea1188328a6b2d99b8abac699