### PR TITLE
Update deps and optional GUI extras

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Lint and Test
 on: [push, pull_request]
 
 jobs:
-  build:
+  lint-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -10,6 +10,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -r requirements.txt
+      - run: pip install music21
       - run: bash scripts/ci_groove.sh
       - run: pytest -q
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,8 @@ bash setup.sh
 or equivalently
 
 ```bash
-pip install -r requirements.txt
-pip install -r requirements-optional.txt  # optional WAV support
-pip install -e .[audio,gui,rnn,essentia]  # optional extras
-pip install click  # required for the groove sampler CLI
-pip install modular-composer[audio]  # quick install via PyPI
+pip install -r requirements.txt      # core + music21
+pip install -e .[gui]                # optional GUI
 ```
 
 Without these packages `pytest` and the composer modules will fail to import.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@ See [Groove Sampler](groove_sampler.md) for training drum models.
 Auxiliary conditioning and deterministic sampling are covered in
 [Aux Features](aux_features.md).
 
-Install optional extras for the GUI and RNN baseline:
-`pip install -e .[audio,gui,rnn,essentia]`.
+Install optional extras for the GUI:
+`pip install -e .[gui]`.
 
 For a live comparison of the n-gram and RNN models check out the
 Streamlit GUI (run with `modcompose gui`):

--- a/modular_composer/__init__.py
+++ b/modular_composer/__init__.py
@@ -7,7 +7,7 @@ __all__ = ["__version__"]
 try:
     __version__ = version("modular_composer")
 except PackageNotFoundError:
-    __version__ = "0.1.1"
+    __version__ = "0.9.0"
 
 _spec = util.spec_from_file_location(
     "_legacy_modular_composer", Path(__file__).resolve().parent.parent / "modular_composer.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name="Your Name", email="you@example.com" },
 ]
 dependencies = [
-  "music21>=9.6.0",
+  "music21~=8.2",
   "numpy>=1.26.4,<2.0.0",
   "PyYAML>=6.0",
   "click>=8",
@@ -45,7 +45,11 @@ groove = [
   "pretty_midi>=0.2.10",
   "librosa>=0.10",
 ]
-gui = ["streamlit>=1.30", "plotly>=5.18", "sounddevice>=0.4"]
+gui = [
+  "streamlit",
+  "altair",
+  "pandas",
+]
 rnn = ["torch>=2.1"]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-music21>=9.6.0
+music21~=8.2
 pretty_midi>=0.2.10
 numpy>=1.26.4,<2.0.0
 PyYAML>=6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ description = OtoKotoba Modular Composer
 # コードパッケージのみ自動検出
 packages = find:
 install_requires =
-    music21>=9.6.0
+    music21~=8.2
     pretty_midi>=0.2.10
     numpy>=1.26.4,<2.0.0
     PyYAML>=6.0
@@ -15,7 +15,13 @@ install_requires =
     pydub>=0.25
     mido>=1.3.0
     scipy>=1.10
-    tomli>=2.0
+tomli>=2.0
+
+[options.extras_require]
+gui =
+    streamlit
+    altair
+    pandas
 
 [options.packages.find]
 # コード以外のトップレベルフォルダを除外

--- a/tests/test_generate_bar_legacy.py
+++ b/tests/test_generate_bar_legacy.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
-import pretty_midi
 import pytest
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+import pretty_midi
 
 from utilities import groove_sampler_ngram as gs
 

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -1,6 +1,11 @@
 import importlib
 from pathlib import Path
 
+import pytest
+pytest.importorskip("streamlit", reason="GUI deps not installed in CI")
+pytest.importorskip("altair", reason="GUI deps not installed in CI")
+pytest.importorskip("pandas", reason="GUI deps not installed in CI")
+
 import pretty_midi
 
 from utilities import groove_sampler_ngram

--- a/tools/streamlit_gui.py
+++ b/tools/streamlit_gui.py
@@ -10,13 +10,12 @@ except Exception:  # pragma: no cover - optional dependency
     st = None
 
 try:
-    import altair as alt
-    import pandas as pd
-except Exception:  # pragma: no cover - altair/pandas optional
-    alt = None
-    pd = None  # type: ignore
-
-from utilities import groove_sampler_ngram as gs
+    from utilities import groove_sampler_ngram as gs
+except Exception as e:  # pragma: no cover - optional dependency
+    gs = None  # type: ignore
+    _GS_ERROR = e
+else:
+    _GS_ERROR = None
 
 
 def _hit_density(events: Iterable[gs.Event]) -> list[dict[str, object]]:
@@ -42,6 +41,10 @@ def generate_midi(
     humanize_micro: bool = False,
 ) -> Path:
     """Return path to a temporary MIDI preview."""
+    if gs is None:
+        raise ImportError(
+            "pretty_midi is required for MIDI generation"
+        ) from _GS_ERROR
     history: list[gs.State] = []
     events: list[gs.Event] = []
     for bar in range(bars):
@@ -63,6 +66,13 @@ def generate_midi(
 
 
 if st is not None:
+
+    try:
+        import altair as alt
+        import pandas as pd
+    except Exception:  # pragma: no cover - altair/pandas optional
+        alt = None
+        pd = None  # type: ignore
 
     def _main() -> None:  # pragma: no cover - UI
         st.sidebar.title("Groove Visualiser")


### PR DESCRIPTION
## Summary
- pin music21~=8.2 and add GUI extras
- guard streamlit GUI imports and provide pretty_midi fallback
- skip GUI tests when deps absent
- ignore deprecation warnings for legacy bar tests
- update CI workflow and documentation
- bump version to 0.9.0

## Testing
- `ruff check .`
- `mypy --strict modular_composer utilities tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f2e75d2c8328a92735479298f5b3