### PR TITLE
Fix warnings in loop ingestion and pytest config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,10 +2,11 @@
 testpaths =
     tests
     tools
-norecursedirs = アーカイブ
+norecursedirs = .git .hg .svn _build tmp* .venv アーカイブ
 addopts = --dry-run
 markers =
     ess_optional: tests that require the Essentia backend
+    slow: marks tests as slow
 
 [tool:pytest]
 filterwarnings =


### PR DESCRIPTION
## Summary
- avoid DeprecationWarning and clamp warnings in `loop_ingest`
- register `slow` mark and restore default `norecursedirs` in `pytest.ini`

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68621e882fc08328aebaf511b6f7a8e6