### PR TITLE
Implement basic emotion-based bass rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,5 +516,32 @@ Add `--update` to overwrite the expected files after intentional changes.
 
 This JSON can then be fed to later synchronization tools.
 
+## Bass Generator Usage
+
+Bass lines can be generated directly from an emotion profile. The YAML file
+`data/emotion_profile.yaml` defines riffs per emotion. Render a bass part
+locked to kick drums:
+
+```python
+from music21 import instrument
+from generator.bass_generator import BassGenerator
+
+gen = BassGenerator(
+    part_name="bass",
+    default_instrument=instrument.AcousticBass(),
+    global_tempo=120,
+    global_time_signature="4/4",
+    global_key_signature_tonic="C",
+    global_key_signature_mode="major",
+    emotion_profile_path="data/emotion_profile.yaml",
+)
+part = gen.render_part(
+    emotion="joy",
+    key_signature="C",
+    tempo_bpm=120,
+    groove_history=[0, 1, 2, 3],
+)
+```
+
 ## License
 This project is licensed under the [MIT License](LICENSE).

--- a/data/emotion_profile.yaml
+++ b/data/emotion_profile.yaml
@@ -1,0 +1,7 @@
+joy:
+  bass_patterns:
+    - riff: [1, b3, 5, 6]
+      velocity: mid
+      swing: off
+  octave_pref: mid
+  length_beats: 4

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@ Browse the API reference to learn how to integrate the generators into your work
 See [Groove Sampler](groove_sampler.md) for training drum models.
 Auxiliary conditioning and deterministic sampling are covered in
 [Aux Features](aux_features.md).
+For an example of emotion-driven bass parts see the *Bass Generator Usage*
+section in the project README.
 
 Install optional extras for the GUI:
 `pip install -e .[gui]`.

--- a/scripts/ci_groove_bass.sh
+++ b/scripts/ci_groove_bass.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+bash scripts/ci_groove.sh
+python - <<'PY'
+import tempfile
+from pathlib import Path
+from music21 import instrument
+from generator.drum_generator import DrumGenerator
+from generator.bass_generator import BassGenerator
+from utilities import groove_sampler_ngram as gs
+
+with tempfile.TemporaryDirectory() as d:
+    # train tiny groove model
+    pm_dir = Path(d)/"mid"
+    pm_dir.mkdir()
+    for i in range(2):
+        path = pm_dir/f"{i}.mid"
+        open(path, "wb").close()
+    model = gs.train(pm_dir, order=1)
+    events = gs.sample(model, bars=4)
+    kicks = [e.offset for e in events.events if e.drum == "kick"]
+    drum = DrumGenerator(part_name="drums", part_parameters={}, default_instrument=instrument.Woodblock(), global_tempo=120, global_time_signature="4/4", global_key_signature_tonic="C", global_key_signature_mode="major")
+    drum.render_kick_track(4.0)
+    bass = BassGenerator(part_name="bass", default_instrument=instrument.AcousticBass(), global_tempo=120, global_time_signature="4/4", global_key_signature_tonic="C", global_key_signature_mode="major", emotion_profile_path="data/emotion_profile.yaml")
+    part = bass.render_part(emotion="joy", key_signature="C", tempo_bpm=120, groove_history=kicks)
+    assert len(part.notes) == 4
+PY

--- a/tests/test_bass_kick_lock.py
+++ b/tests/test_bass_kick_lock.py
@@ -39,3 +39,24 @@ def test_kick_lock_velocity():
     part = gen.compose(section_data=section, shared_tracks={"kick_offsets": [0, 1, 2, 3]})
     velocities = [n.volume.velocity for n in part.flatten().notes]
     assert velocities == [75, 75, 75, 75]
+
+
+def test_render_part_kick_alignment():
+    gen = BassGenerator(
+        part_name="bass",
+        default_instrument=instrument.AcousticBass(),
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        emotion_profile_path="data/emotion_profile.yaml",
+    )
+    part = gen.render_part(
+        emotion="joy",
+        key_signature="C",
+        tempo_bpm=120,
+        groove_history=[0.0, 1.0, 2.0, 3.0],
+    )
+    offsets = [n.offset for n in part.notes]
+    for expected, actual in zip([0.0, 1.0, 2.0, 3.0], offsets):
+        assert abs(expected - actual) <= 1 / 480

--- a/tests/test_bass_pattern_selection.py
+++ b/tests/test_bass_pattern_selection.py
@@ -1,0 +1,17 @@
+from music21 import instrument
+from generator.bass_generator import BassGenerator
+
+
+def test_emotion_pattern_selection():
+    gen = BassGenerator(
+        part_name="bass",
+        default_instrument=instrument.AcousticBass(),
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        emotion_profile_path="data/emotion_profile.yaml",
+    )
+    part = gen.render_part(emotion="joy", key_signature="C", tempo_bpm=120)
+    pitches = [n.pitch.midi for n in part.notes]
+    assert pitches == [48, 51, 55, 57]

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -71,6 +71,7 @@ from .tempo_utils import (
 )
 from .velocity_curve import PREDEFINED_CURVES, resolve_velocity_curve
 from .velocity_smoother import EMASmoother, VelocitySmoother
+from .emotion_profile_loader import load_emotion_profile
 
 __all__ = [
     "MIN_NOTE_DURATION_QL",
@@ -105,6 +106,7 @@ __all__ = [
     "EssentiaUnavailable",
     "detect_consonant_peaks",
     "extract_to_json",
+    "load_emotion_profile",
     "groove_sampler_ngram",
 ]
 

--- a/utilities/emotion_profile_loader.py
+++ b/utilities/emotion_profile_loader.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def load_emotion_profile(path: str | Path) -> Dict[str, Any]:
+    """Load emotion profile YAML and return as dictionary."""
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Emotion profile must be a mapping")
+    return data


### PR DESCRIPTION
## Summary
- add emotion profile YAML and loader
- extend BassGenerator with `render_part` for emotion-based riffs
- include humanization and kick alignment
- add tests for pattern selection and kick lock
- add CI script for groove+bass
- document Bass Generator usage

## Testing
- `ruff check .`
- `mypy modular_composer utilities tests --strict --warn-unused-ignores`
- `pytest -q tests/test_bass_pattern_selection.py tests/test_bass_kick_lock.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68622d06dec88328a106b0c2498aa5d6