### PR TITLE
Add velocity tiers and swing handling to BassGenerator

### DIFF
--- a/scripts/ci_groove_bass.sh
+++ b/scripts/ci_groove_bass.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+start=$(date +%s)
 bash scripts/ci_groove.sh
 python - <<'PY'
 import tempfile
@@ -25,3 +26,9 @@ with tempfile.TemporaryDirectory() as d:
     part = bass.render_part(emotion="joy", key_signature="C", tempo_bpm=120, groove_history=kicks)
     assert len(part.notes) == 4
 PY
+end=$(date +%s)
+elapsed=$((end - start))
+if [ "$elapsed" -gt 60 ]; then
+  echo "ci_groove_bass.sh took ${elapsed}s" >&2
+  exit 1
+fi

--- a/tests/test_bass_fallback.py
+++ b/tests/test_bass_fallback.py
@@ -1,0 +1,20 @@
+from music21 import instrument
+from generator.bass_generator import BassGenerator
+
+
+def test_unknown_emotion_fallback():
+    gen = BassGenerator(
+        part_name="bass",
+        default_instrument=instrument.AcousticBass(),
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        emotion_profile_path="data/emotion_profile.yaml",
+    )
+    part = gen.render_part(emotion="mystery", key_signature="C", tempo_bpm=120)
+    assert len(part.notes) == 4
+    velocities = [n.volume.velocity for n in part.notes]
+    assert all(70 <= v <= 85 for v in velocities)
+    pitches = [n.pitch.midi for n in part.notes]
+    assert pitches == [48, 55, 48, 55]

--- a/tests/test_bass_velocity_swing.py
+++ b/tests/test_bass_velocity_swing.py
@@ -1,0 +1,35 @@
+import textwrap
+from music21 import instrument
+from generator.bass_generator import BassGenerator
+
+
+def test_velocity_and_swing(tmp_path):
+    yaml = textwrap.dedent(
+        """
+        cool:
+          bass_patterns:
+            - riff: [1,5,1,5,1,5,1,5]
+              velocity: high
+              swing: on
+          octave_pref: mid
+          length_beats: 4
+        """
+    )
+    path = tmp_path / "ep.yaml"
+    path.write_text(yaml)
+    gen = BassGenerator(
+        part_name="bass",
+        default_instrument=instrument.AcousticBass(),
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        emotion_profile_path=str(path),
+        global_settings={"swing_ratio": 0.1},
+    )
+    part = gen.render_part(emotion="cool", key_signature="C", tempo_bpm=120)
+    velocities = [n.volume.velocity for n in part.notes]
+    assert all(100 <= v <= 110 for v in velocities)
+    offsets = [n.offset for n in part.notes]
+    assert abs(offsets[1] - 0.55) < 1e-3
+    assert abs(part.notes[0].duration.quarterLength - 0.45) < 1e-3

--- a/utilities/accent_mapper.py
+++ b/utilities/accent_mapper.py
@@ -7,7 +7,46 @@ from .velocity_smoother import EMASmoother
 
 
 class AccentMapper:
-    """Map accent intensity and ghost-hat density using a vocal heatmap."""
+    """Map accent intensity and ghost-hat density using a vocal heatmap.
+
+    The class also provides a helper :func:`map_layer` for converting simple
+    velocity tiers such as ``"low"`` or ``"mid"`` into concrete MIDI velocity
+    values.  This mirrors the behaviour used in a few tests where configuration
+    files specify only an approximate dynamic range.
+    """
+
+    #: Mapping of tier name to inclusive MIDI velocity range
+    VELOCITY_LAYERS = {
+        "low": (40, 55),
+        "mid": (70, 85),
+        "high": (100, 110),
+    }
+
+    @staticmethod
+    def map_layer(layer: str, *, rng: random.Random | None = None) -> int:
+        """Return a MIDI velocity value for ``layer``.
+
+        Parameters
+        ----------
+        layer:
+            Name of the velocity tier (``"low"``, ``"mid"`` or ``"high"``).
+        rng:
+            Optional random generator used when picking a value from the tier
+            range.
+
+        Returns
+        -------
+        int
+            Velocity value clamped to ``1..127``. Unknown tiers default to
+            ``"mid"``.
+        """
+
+        rng = rng or random.Random()
+        bounds = AccentMapper.VELOCITY_LAYERS.get(layer.lower(), AccentMapper.VELOCITY_LAYERS["mid"])
+        lo, hi = bounds
+        if lo > hi:
+            lo, hi = hi, lo
+        return max(1, min(127, rng.randint(int(lo), int(hi))))
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- map velocity tiers via `AccentMapper.map_layer`
- handle unknown emotion with neutral fallback
- support swing timing in `BassGenerator.render_part`
- clamp bass pitch range after degree conversion
- adjust CI script to time execution
- add tests for velocity/swing and fallback behaviour

## Testing
- `ruff check . --select I,U`
- `mypy modular_composer utilities tests --strict --warn-unused-ignores`
- `pytest -q tests/test_bass_velocity_swing.py tests/test_bass_fallback.py`

------
https://chatgpt.com/codex/tasks/task_e_686231b9a1488328a52c078defd0ec15