### PR TITLE
Add live CLI and optional dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          pip install -e ".[dev]"
+          pip install -e ".[dev,groove]"
       - name: Restore Essentia wheel cache
         if: runner.os == 'Linux'
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - run: bash scripts/ci_groove.sh
       - run: pytest -q
 
-  rnn:
+  stretch-smoke:
     if: startsWith(github.ref, 'refs/heads/stretch/')
     runs-on: ubuntu-latest
     steps:
@@ -22,4 +22,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - run: pip install -e .[dev,groove,gui,rnn]
       - run: bash scripts/ci_groove_rnn.sh

--- a/README.md
+++ b/README.md
@@ -275,9 +275,9 @@ An RNN baseline is available for comparison:
 modcompose rnn train loops.json --epochs 1 --out rnn.pt
 modcompose rnn sample rnn.pt -l 4 > rnn.mid
 ```
-Stream a trained model in real time:
+Stream a trained model live:
 ```bash
-modcompose realtime rnn.pt --bpm 100 --duration 16
+modcompose live rnn.pt --backend rnn --bpm 100
 ```
 Real-time audio requires the `sounddevice` backend and currently works on
 Linux and macOS only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ groove = [
   "librosa>=0.10",
 ]
 gui = [
-  "streamlit",
+  "streamlit>=1.32",
   "altair",
   "pandas",
 ]
-rnn = ["torch>=2.1"]
+rnn = ["torch>=2.3.0"]
 
 [project.scripts]
 modcompose = "modular_composer.cli:main"
@@ -102,4 +102,5 @@ include = ["modular_composer*", "utilities*"]
 [tool.pytest.ini_options]
 markers = [
     "ci_perf: performance gate"
+    , "stretch: stretch smoke tests"
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ markers =
     ess_optional: tests that require the Essentia backend
     slow: marks tests as slow
     ci_perf: performance gate
+    stretch: stretch smoke tests
 
 [tool:pytest]
 filterwarnings =

--- a/tests/test_live_cli.py
+++ b/tests/test_live_cli.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from modular_composer import cli
+from utilities import groove_sampler_ngram, live_player
+
+
+@pytest.mark.stretch
+def test_live_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy = tmp_path / "m.pkl"
+    dummy.write_text("dummy")
+
+    monkeypatch.setattr(groove_sampler_ngram, "load", lambda p: None)
+    monkeypatch.setattr(
+        groove_sampler_ngram,
+        "_generate_bar",
+        lambda hist, model, rng=None: ([{"instrument": "kick", "offset": 0.0}], []),
+    )
+
+    called = {
+        "val": False,
+    }
+
+    def fake_play(sampler, bpm: float) -> None:
+        called["val"] = True
+
+    monkeypatch.setattr(live_player, "play_live", fake_play)
+
+    runner = CliRunner()
+    res = runner.invoke(
+        cli.cli,
+        ["live", str(dummy), "--backend", "ngram", "--bpm", "100"],
+    )
+    assert res.exit_code == 0
+    assert called["val"]

--- a/utilities/live_player.py
+++ b/utilities/live_player.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .streaming_sampler import BaseSampler, RealtimePlayer
+
+
+def play_live(sampler: BaseSampler, bpm: float) -> None:
+    """Stream events from ``sampler`` in real time until interrupted."""
+    player = RealtimePlayer(sampler, bpm=bpm)
+    try:
+        while True:
+            player.play(bars=1)
+    except KeyboardInterrupt:
+        return


### PR DESCRIPTION
## Summary
- add a `live` command for streaming events
- implement `utilities.live_player` helper
- move heavy deps to extras and update versions
- update CI dependency extras
- document `live` usage
- test CLI via new pytest

## Testing
- `ruff check . --output-format=github`
- `mypy modular_composer utilities tests --strict`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686298659eb083289ae10296f75ed1a6