### PR TITLE
Implement ii-V buildup for bass

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,19 @@ The first beat snaps to the nearest kick within the opening eighth note, then
 the bass mirrors the lead melody around the chord root.
 TODO: add GIF demo
 
+### ii–V Build-up
+
+When the upcoming bar resolves back to the song's tonic, `render_part()` will
+walk up the last two beats to lead into that cadence. Beats one and two still
+use Kick‑Lock → Mirror‑Melody while beats three and four outline the ii or V
+approach.
+
+```python
+next_sec = {"chord": "Cmaj7"}
+part = gen.render_part({"chord": "G7", "groove_kicks": [0], "melody": []},
+                       next_section_data=next_sec)
+```
+
 ## Hi-Fi RNN Backend
 
 Groove generation can now leverage a Lightning-based RNN with attention. Train a

--- a/generator/bass_generator.py
+++ b/generator/bass_generator.py
@@ -13,6 +13,7 @@ from music21 import (
 )
 from music21 import (
     harmony,
+    key,
     meter,
     note,
     pitch,
@@ -23,10 +24,8 @@ from music21 import (
     volume as m21volume,
 )
 
-from utilities import humanizer
+from utilities import MIN_NOTE_DURATION_QL, humanizer
 from utilities.accent_mapper import AccentMapper
-from utilities import MIN_NOTE_DURATION_QL
-
 from utilities.emotion_profile_loader import load_emotion_profile
 from utilities.velocity_curve import resolve_velocity_curve
 
@@ -1904,6 +1903,64 @@ class BassGenerator(BasePartGenerator):
                 velocity=AccentMapper.map_layer("low", rng=self._rng)
             )
             notes_data.append((grid_off, bn))
+
+        # --------------------------------------------------------------
+        # ii-V build-up detection and generation (beats >= 3 only)
+        # --------------------------------------------------------------
+        key_tonic = (
+            self.global_key_signature_tonic or self.global_key_tonic or "C"
+        )
+        key_mode = (
+            self.global_key_signature_mode or self.global_key_mode or "major"
+        )
+        try:
+            key_obj = key.Key(key_tonic, key_mode)
+        except Exception:
+            key_obj = key.Key(key_tonic)
+
+        build_up = False
+        next_label = None
+        if next_section_data:
+            next_label = next_section_data.get("chord") or next_section_data.get(
+                "chord_symbol_for_voicing"
+            )
+        if next_label:
+            try:
+                next_root = harmony.ChordSymbol(next_label).root()
+            except Exception:
+                next_root = None
+            if next_root and key_obj.getScaleDegreeFromPitch(next_root) == 1:
+                build_up = True
+
+        if build_up:
+            deg_now = key_obj.getScaleDegreeFromPitch(root_pitch)
+            pattern_ints: list[int]
+            pattern_root = root_pitch
+            if deg_now == 2:
+                pattern_ints = [0, 3, 7, 9]
+            elif deg_now == 5:
+                pattern_ints = [0, 4, 7, 8]
+            else:
+                pattern_root = key_obj.pitchFromDegree(5)
+                pattern_root.octave = root_pitch.octave
+                pattern_ints = [0, 2, 4, 5]
+            pattern_pitches = [pattern_root.transpose(i) for i in pattern_ints]
+
+            build_offsets = [2.0, 3.0]
+            for b_off, p_obj in zip(build_offsets, pattern_pitches[2:]):
+                midi_val = p_obj.midi
+                while midi_val < self.bass_range_lo:
+                    midi_val += 12
+                while midi_val > self.bass_range_hi:
+                    midi_val -= 12
+                p_obj.midi = midi_val
+                notes_data = [d for d in notes_data if not (b_off <= d[0] < b_off + 1.0)]
+                n_bu = note.Note(p_obj)
+                n_bu.duration = m21duration.Duration(1.0)
+                n_bu.volume = m21volume.Volume(
+                    velocity=AccentMapper.map_layer("mid", rng=self._rng)
+                )
+                notes_data.append((b_off, n_bu))
 
         notes_data.sort(key=lambda x: x[0])
         merged: list[tuple[float, note.Note]] = []

--- a/tests/test_bass_build_octave_clamp.py
+++ b/tests/test_bass_build_octave_clamp.py
@@ -1,0 +1,30 @@
+from music21 import instrument
+from generator.bass_generator import BassGenerator
+
+
+def make_gen() -> BassGenerator:
+    gs = {"bass_range_lo": 40, "bass_range_hi": 72}
+    cfg = {"global_settings": {"key_tonic": "Bb", "key_mode": "major"}}
+    return BassGenerator(
+        part_name="bass",
+        default_instrument=instrument.AcousticBass(),
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="Bb",
+        global_key_signature_mode="major",
+        main_cfg=cfg,
+        global_settings=gs,
+    )
+
+
+def test_build_up_range_clamp() -> None:
+    gen = make_gen()
+    section = {
+        "key_signature": "Bb",
+        "chord": "F7",
+        "melody": [],
+        "groove_kicks": [0.0],
+    }
+    part = gen.render_part(section, next_section_data={"chord": "Bbmaj7"})
+    for n in part.flatten().notes:
+        assert n.pitch.midi >= gen.bass_range_lo

--- a/tests/test_bass_iiv_build.py
+++ b/tests/test_bass_iiv_build.py
@@ -1,0 +1,37 @@
+from music21 import instrument
+from generator.bass_generator import BassGenerator
+
+
+def make_gen() -> BassGenerator:
+    return BassGenerator(
+        part_name="bass",
+        default_instrument=instrument.AcousticBass(),
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        main_cfg={"global_settings": {"key_tonic": "C", "key_mode": "major"}},
+    )
+
+
+def _get_note_at(notes, target_off):
+    for n in notes:
+        if abs(float(n.offset) - target_off) <= 1 / 480:
+            return n
+    raise AssertionError(f"note at {target_off} not found")
+
+
+def test_build_up_pattern() -> None:
+    gen = make_gen()
+
+    section_v = {
+        "key_signature": "C",
+        "chord": "G7",
+        "melody": [],
+        "groove_kicks": [0.0],
+    }
+    part = gen.render_part(section_v, next_section_data={"chord": "Cmaj7"})
+    notes = list(part.flatten().notes)
+    assert abs(notes[0].offset - 0.0) <= 1 / 480
+    assert _get_note_at(notes, 2.0).pitch.name == "D"
+    assert _get_note_at(notes, 3.0).pitch.name in {"E-", "D#"}


### PR DESCRIPTION
## Summary
- add ii–V buildup logic to BassGenerator render_part
- clamp range for generated buildup notes
- document buildup usage in README
- test for correct buildup pattern and range clamping

## Testing
- `ruff check .`
- `mypy --strict`
- `pytest tests/test_bass_iiv_build.py tests/test_bass_build_octave_clamp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862cb9fad408328a2336ca15e531333