### PR TITLE
Implement Data-Ops auto-tag, augmentation pipeline & GUI v2

### DIFF
--- a/.github/workflows/data-ops-smoke.yml
+++ b/.github/workflows/data-ops-smoke.yml
@@ -10,8 +10,8 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install -e .[dev,gui]
+      - run: pip install -e .[gui,rnn]
       - run: ruff check data_ops streamlit_app_v2.py tests/test_auto_tag.py tests/test_augment.py tests/test_gui_import.py
       - run: mypy data_ops streamlit_app_v2.py tests/test_auto_tag.py tests/test_augment.py tests/test_gui_import.py --strict
-      - run: pytest tests/test_auto_tag.py tests/test_augment.py tests/test_gui_import.py -q
+      - run: pytest -m "data_ops or gui" -q
         timeout-minutes: 2

--- a/README.md
+++ b/README.md
@@ -518,6 +518,35 @@ You can override this on the command line:
 python modular_composer.py --main-cfg config/main_cfg.yml --consonant-sync-mode note
 ```
 
+## Auto-Tag & Augmentation
+
+Automatically infer section and intensity labels for your loop library:
+
+```bash
+modcompose tag loops/ --out meta.json --k-intensity 3 --csv summary.csv
+```
+
+This writes per-bar metadata to `meta.json` and a flat CSV summary. Use the augmentation
+tool to apply swing, shuffle and transposition before training:
+
+```bash
+modcompose augment in.mid --swing 54 --transpose 2 -o out.mid
+```
+
+Combine both with the training commands via `--auto-tag`.
+
+## GUI v2 Walkthrough
+
+Launch the updated Streamlit interface:
+
+```bash
+modcompose gui
+```
+
+Upload a model in the sidebar, choose backend and bars to generate, then select the
+desired section and intensity from the dropdowns populated by the model metadata. Click
+"Generate" to view a pianoroll heatmap and audition the groove directly in the browser.
+
 Passing `--lag` values below zero will pre-hit the drums. If this causes
 negative beat offsets, set `clip_at_zero=true` in your configuration or pass the
 parameter when using the synchroniser programmatically.

--- a/data_ops/augment.py
+++ b/data_ops/augment.py
@@ -6,12 +6,12 @@ from pathlib import Path
 import pretty_midi
 
 
-def swing(pm: pretty_midi.PrettyMIDI, amount: float) -> pretty_midi.PrettyMIDI:
-    """Apply swing by delaying off-beat eighths by ``amount`` percent."""
+def swing(pm: pretty_midi.PrettyMIDI, ratio: float) -> pretty_midi.PrettyMIDI:
+    """Apply swing feel by moving off-beats by ``(ratio-50) %`` of a 16th."""
     tempo = pm.get_tempo_changes()[1]
     bpm = float(tempo[0]) if getattr(tempo, "size", 0) else 120.0
     beat = 60.0 / bpm
-    offset = beat * 0.5 * (amount / 100)
+    offset = (ratio - 50.0) / 100.0 * (beat / 6)
     for inst in pm.instruments:
         for note in inst.notes:
             beat_pos = note.start / beat
@@ -21,10 +21,19 @@ def swing(pm: pretty_midi.PrettyMIDI, amount: float) -> pretty_midi.PrettyMIDI:
     return pm
 
 
-def shuffle(pm: pretty_midi.PrettyMIDI, seed: int | None = None) -> pretty_midi.PrettyMIDI:
+def shuffle(
+    pm: pretty_midi.PrettyMIDI, prob: float, seed: int | None = None
+) -> pretty_midi.PrettyMIDI:
     rng = random.Random(seed)
     for inst in pm.instruments:
-        rng.shuffle(inst.notes)
+        inst.notes.sort(key=lambda n: n.start)
+        for i in range(len(inst.notes) - 1):
+            if rng.random() < prob:
+                a = inst.notes[i]
+                b = inst.notes[i + 1]
+                a.start, b.start = b.start, a.start
+                a.end, b.end = b.end, a.end
+        inst.notes.sort(key=lambda n: n.start)
     return pm
 
 
@@ -35,6 +44,22 @@ def transpose(pm: pretty_midi.PrettyMIDI, semitone: int) -> pretty_midi.PrettyMI
     return pm
 
 
+def apply_pipeline(
+    pm: pretty_midi.PrettyMIDI,
+    *,
+    swing_ratio: float | None = None,
+    shuffle_prob: float | None = None,
+    transpose_amt: int = 0,
+) -> pretty_midi.PrettyMIDI:
+    if swing_ratio is not None:
+        pm = swing(pm, swing_ratio)
+    if shuffle_prob is not None and shuffle_prob > 0:
+        pm = shuffle(pm, shuffle_prob)
+    if transpose_amt:
+        pm = transpose(pm, transpose_amt)
+    return pm
+
+
 def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI entry
     import argparse
 
@@ -42,16 +67,16 @@ def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI entry
     ap.add_argument("midi", type=Path)
     ap.add_argument("--swing", type=float, default=0.0)
     ap.add_argument("--transpose", type=int, default=0)
-    ap.add_argument("--shuffle", action="store_true")
+    ap.add_argument("--shuffle", type=float, default=0.0)
     ap.add_argument("-o", "--out", type=Path, required=True)
     ns = ap.parse_args(argv)
     pm = pretty_midi.PrettyMIDI(str(ns.midi))
-    if ns.swing:
-        pm = swing(pm, ns.swing)
-    if ns.shuffle:
-        pm = shuffle(pm)
-    if ns.transpose:
-        pm = transpose(pm, ns.transpose)
+    pm = apply_pipeline(
+        pm,
+        swing_ratio=ns.swing if ns.swing else None,
+        shuffle_prob=ns.shuffle if ns.shuffle else None,
+        transpose_amt=ns.transpose,
+    )
     pm.write(str(ns.out))
     print(f"wrote {ns.out}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ dependencies = [
   "scipy>=1.10",
   "tomli>=2.0",
   "soundfile>=0.12",
-  "audioread>=2.1.9"
-  , "hmmlearn>=0.3"
+  "audioread>=2.1.9",
+  "hmmlearn>=0.3",
   "music21>=7.3",
   "numpy>=1.26",
   "click>=8.1",
@@ -45,7 +45,7 @@ groove = [
   "pretty_midi>=0.2.10",
   "librosa>=0.10",
 ]
-gui = ["streamlit>=1.32"]
+gui = ["streamlit>=1.32", "plotly>=5"]
 rnn = ["torch==2.3.0", "pytorch_lightning==2.2.4", "optuna==3.6.1"]
 live = ["mido>=1.3", "python-rtmidi>=1.5"]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,8 @@ markers =
     slow: marks tests as slow
     ci_perf: performance gate
     stretch: stretch smoke tests
+    data_ops: data operations tests
+    gui: gui tests
     no_midi_port: skip tests when no MIDI input is available
 
 [tool:pytest]

--- a/tests/test_augment.py
+++ b/tests/test_augment.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pretty_midi
+import pytest
 
 from data_ops.augment import swing
 
@@ -15,11 +16,12 @@ def _make_midi(path: Path) -> pretty_midi.PrettyMIDI:
     return pm
 
 
+@pytest.mark.data_ops
 def test_swing(tmp_path: Path) -> None:
     midi = tmp_path / "a.mid"
     pm = _make_midi(midi)
-    swung = swing(pm, 50)
+    swung = swing(pm, 60)
     beat = 60.0 / 120
     tick = beat / 480
-    expected = 0.25 + 0.125
+    expected = 0.25 + (60 - 50) / 100 * beat / 6
     assert abs(swung.instruments[0].notes[1].start - expected) < 2 * tick

--- a/tests/test_auto_tag.py
+++ b/tests/test_auto_tag.py
@@ -1,20 +1,25 @@
 from pathlib import Path
 
-from data_ops.auto_tag import auto_tag
 import pretty_midi
+import pytest
+
+from data_ops.auto_tag import auto_tag
 
 
 def _make_midi(path: Path) -> None:
     pm = pretty_midi.PrettyMIDI(initial_tempo=120)
     inst = pretty_midi.Instrument(program=0, is_drum=True)
-    for i in range(4):
-        inst.notes.append(pretty_midi.Note(velocity=80, pitch=36, start=i * 0.5, end=i * 0.5 + 0.1))
+    for i in range(8):
+        inst.notes.append(
+            pretty_midi.Note(velocity=80, pitch=36, start=i * 0.25, end=i * 0.25 + 0.1)
+        )
     pm.instruments.append(inst)
     pm.write(str(path))
 
 
+@pytest.mark.data_ops
 def test_auto_tag(tmp_path: Path) -> None:
     midi = tmp_path / "a.mid"
     _make_midi(midi)
     meta = auto_tag(tmp_path)
-    assert meta[midi.name]["intensity"] and meta[midi.name]["section"]
+    assert meta[midi.name][0]["intensity"] and meta[midi.name][0]["section"]

--- a/tests/test_gui_import.py
+++ b/tests/test_gui_import.py
@@ -4,5 +4,6 @@ import pytest
 
 streamlit = pytest.importorskip("streamlit")
 
+@pytest.mark.gui
 def test_gui_import() -> None:
     assert importlib.import_module("streamlit_app_v2")


### PR DESCRIPTION
## Summary
- add per-bar auto tagging with intensity clustering and HMM fallback
- add swing/shuffle/transpose augmentation with CLI pipeline
- integrate new options into CLI and rnn training
- implement Streamlit GUI v2 with presets and heatmap
- update tests and CI workflow
- document auto-tag, augmentation and GUI v2

## Testing
- `ruff check .`
- `mypy modular_composer utilities tests --strict`
- `pytest -m "data_ops or gui" -q`


------
https://chatgpt.com/codex/tasks/task_e_6862fcb845788328afb38aaa1c2d3772