### PR TITLE
Brush-up Data-Ops & GUI v2

### DIFF
--- a/.github/workflows/data-ops-smoke.yml
+++ b/.github/workflows/data-ops-smoke.yml
@@ -10,8 +10,8 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install -e .[gui,rnn]
+      - run: pip install -e .[gui,rnn,data_ops]
       - run: ruff check data_ops streamlit_app_v2.py tests/test_auto_tag.py tests/test_augment.py tests/test_gui_import.py
       - run: mypy data_ops streamlit_app_v2.py tests/test_auto_tag.py tests/test_augment.py tests/test_gui_import.py --strict
       - run: pytest -m "data_ops or gui" -q
-        timeout-minutes: 2
+        timeout-minutes: 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 dependencies = [
   "music21~=8.2",
-  "numpy>=1.26.4,<2.0.0",
+  "numpy>=1.26,<2.0.0",
   "PyYAML>=6.0",
   "click>=8",
   "pydantic>=2.7",
@@ -23,10 +23,6 @@ dependencies = [
   "tomli>=2.0",
   "soundfile>=0.12",
   "audioread>=2.1.9",
-  "hmmlearn>=0.3",
-  "music21>=7.3",
-  "numpy>=1.26",
-  "click>=8.1",
   "pretty_midi>=0.2",
 ]
 
@@ -48,6 +44,7 @@ groove = [
 gui = ["streamlit>=1.32", "plotly>=5"]
 rnn = ["torch==2.3.0", "pytorch_lightning==2.2.4", "optuna==3.6.1"]
 live = ["mido>=1.3", "python-rtmidi>=1.5"]
+data_ops = ["hmmlearn>=0.3"]
 
 [project.scripts]
 modcompose = "modular_composer.cli:main"

--- a/streamlit_app_v2.py
+++ b/streamlit_app_v2.py
@@ -48,7 +48,7 @@ def main() -> None:
     backend = sidebar.radio("Backend", ["ngram", "rnn"], index=0)
     bars = sidebar.slider("Bars", 1, 32, 4)
     temp = sidebar.slider("Temperature", 0.0, 1.5, 1.0)
-    sections = ["verse", "pre-chorus", "chorus", "bridge"]
+    sections = ["intro", "verse", "chorus", "bridge"]
     intensities = ["low", "mid", "high"]
     if file is not None:
         path = Path(file.name)

--- a/tests/test_auto_tag_ngram.py
+++ b/tests/test_auto_tag_ngram.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pretty_midi
+import pytest
+from click.testing import CliRunner
+
+from modular_composer import cli
+
+
+def _mk_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    for i in range(8):
+        start = i * 0.5
+        inst.notes.append(pretty_midi.Note(velocity=80, pitch=36, start=start, end=start + 0.1))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+@pytest.mark.data_ops
+def test_auto_tag_train(tmp_path: Path) -> None:
+    _mk_loop(tmp_path / "a.mid")
+    runner = CliRunner()
+    out = tmp_path / "m.pkl"
+    res = runner.invoke(
+        cli.cli,
+        [
+            "groove",
+            "train",
+            str(tmp_path),
+            "--order",
+            "1",
+            "--out",
+            str(out),
+            "--auto-tag",
+            "--no-progress",
+        ],
+    )
+    assert res.exit_code == 0
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add --auto-tag integration test for groove train
- tidy pyproject dependencies and move hmmlearn to data_ops extra
- update Data-Ops smoke workflow installation & timeout
- tweak GUI defaults for v2

## Testing
- `ruff check modular_composer streamlit_app_v2.py data_ops tests --output-format=concise`
- `mypy data_ops streamlit_app_v2.py tests/test_auto_tag.py tests/test_auto_tag_ngram.py tests/test_augment.py tests/test_gui_import.py --strict`
- `pytest -m "data_ops or gui" -q` *(fails: ModuleNotFoundError: music21)*


------
https://chatgpt.com/codex/tasks/task_e_686309f89c5483289abb6952cadfed85