### PR TITLE
Fix realtime engine and CLI optional deps

### DIFF
--- a/generator/bass_generator.py
+++ b/generator/bass_generator.py
@@ -1933,10 +1933,10 @@ class BassGenerator(BasePartGenerator):
                 m_pitch.midi = int(pitch_midi)
             except Exception:
                 continue
-            interval_semitones = (
-                interval.Interval(root_pitch, m_pitch).chromatic.mod12
-            )
-            mirrored = root_pitch.transpose(-interval_semitones)
+            intv = interval.Interval(root_pitch, m_pitch).chromatic.mod12
+            mirrored = root_pitch.transpose(-intv)
+            if mirrored.pitchClass == root_pitch.pitchClass:
+                mirrored = root_pitch
             mirrored = _clamp_pitch_octaves(mirrored)
             bn = note.Note(mirrored)
             bn.duration = m21duration.Duration(float(dur))

--- a/streamlit_app_v2.py
+++ b/streamlit_app_v2.py
@@ -9,7 +9,10 @@ try:
     import plotly.graph_objects as go
 except Exception:  # pragma: no cover - optional dependency
     go = None  # type: ignore[assignment]
-import streamlit as st
+try:
+    import streamlit as st
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    st = None  # type: ignore[assignment]
 
 from utilities import groove_sampler_ngram, groove_sampler_rnn
 from utilities.groove_sampler_ngram import Event

--- a/tests/test_cli_no_rnn.py
+++ b/tests/test_cli_no_rnn.py
@@ -16,4 +16,4 @@ def test_cli_no_rnn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     runner = CliRunner()
     res = runner.invoke(cli.cli, ["rnn", "train", str(loops)])
     assert res.exit_code == 1
-    assert "RNN extras not installed" in res.output
+    assert "Install extras: rnn" in res.output

--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -1209,6 +1209,11 @@ def train_cmd(
         collapsed: dict[str, dict[str, Any]] = {}
         for name, bars in auto.items():
             if not bars:
+                collapsed[name] = {
+                    "section": "verse",
+                    "intensity": "mid",
+                    "heat_bin": 0,
+                }
                 continue
             first = next(iter(bars.values()))
             collapsed[name] = {

--- a/utilities/realtime_engine.py
+++ b/utilities/realtime_engine.py
@@ -8,8 +8,16 @@ from collections.abc import Callable
 from pathlib import Path
 
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
-import torch
+import click
+
+try:  # optional dependency
+    import torch
+except ModuleNotFoundError:  # lightweight install
+    torch: Any | None = None  # type: ignore[assignment]
+else:
+    torch: Any | None
 from . import groove_sampler_rnn
 from .groove_rnn_v2 import GrooveRNN, sample_rnn_v2
 from .groove_sampler_ngram import load as load_ngram, sample as sample_ngram
@@ -63,6 +71,8 @@ class RealtimeEngine:
     ) -> None:
         if backend not in {"rnn", "ngram"}:
             raise ValueError("backend must be 'rnn' or 'ngram'")
+        if backend == "rnn" and torch is None:
+            raise click.ClickException("Install extras: rnn")
         self.model_path = str(model_path)
         self.backend = backend
         if backend == "rnn":
@@ -147,4 +157,7 @@ class RealtimeEngine:
                     time.sleep(delay)
                 sink(ev)
             self._next = fut.result()
+
+
+__all__ = ["RealtimeEngine", "ThreadPoolExecutor"]
 


### PR DESCRIPTION
## Summary
- guard torch import for realtime engine
- improve auto-tag aux defaults
- mirror bass melody intervals correctly
- handle missing RNN extras in CLI
- allow optional Streamlit import
- expose ThreadPoolExecutor from realtime_engine
- update tests for new message

## Testing
- `ruff check .`
- `mypy modular_composer utilities`
- `pytest -q` *(fails: ModuleNotFoundError for music21)*

------
https://chatgpt.com/codex/tasks/task_e_68634b105d6c8328b54b71d1bc081d87