### PR TITLE
Fix test dependencies and EMA init

### DIFF
--- a/.github/workflows/groove.yml
+++ b/.github/workflows/groove.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - run: pip install -e .[groove,test]
+      - run: pip install -e .[groove,test] -r requirements-test.txt
       - run: pip install python-rtmidi
       - name: build cyext
         if: matrix.env.CYTHON == '1'

--- a/README.md
+++ b/README.md
@@ -418,8 +418,9 @@ Velocity histograms can further refine dynamics:
 
 ```bash
 modcompose render spec.yml --velocity-hist groove_hist.pkl \
-    --humanize-velocity 1.0 --ema-alpha 0.2 --humanize-timing 1.0
+    --humanize-velocity 1.0 --ema-alpha 0.2 --humanize-timing 1.0 --seed 42
 ```
+Specifying ``--seed`` makes velocity sampling reproducible.
 
 ### Sampling API
 

--- a/modular_composer/cli.py
+++ b/modular_composer/cli.py
@@ -255,6 +255,8 @@ def _cmd_demo(args: list[str]) -> None:
     ap.add_argument("-o", "--out", type=Path, default=Path("demo.mid"))
     ap.add_argument("--tempo-curve", type=Path)
     ns = ap.parse_args(args)
+    if ns.seed is not None:
+        random.seed(ns.seed)
 
     curve = []
     if ns.tempo_curve:
@@ -278,7 +280,7 @@ def _cmd_sample(args: list[str]) -> None:
     ap.add_argument("model", type=Path)
     ap.add_argument("-l", "--length", type=int, default=4)
     ap.add_argument("--temperature", type=float, default=1.0)
-    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--seed", type=int, default=None)
     ap.add_argument("--cond-velocity", choices=["soft", "hard"], default=None)
     ap.add_argument(
         "--cond-kick", choices=["four_on_floor", "sparse"], default=None
@@ -288,6 +290,8 @@ def _cmd_sample(args: list[str]) -> None:
     ap.add_argument("--lag", type=float, default=10.0)
     ap.add_argument("--tempo-curve", type=Path)
     ns = ap.parse_args(args)
+    if ns.seed is not None:
+        random.seed(ns.seed)
     model = load(ns.model)
     ev = cast(
         list[Event],
@@ -333,7 +337,7 @@ def _cmd_render(args: list[str]) -> None:
     ap.add_argument("spec", type=Path)
     ap.add_argument("-o", "--out", type=Path, default=Path("out.mid"))
     ap.add_argument("--soundfont", type=Path, default=None)
-    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--seed", type=int, default=None)
     ap.add_argument("--velocity-hist", type=Path, default=None)
     ap.add_argument("--ema-alpha", type=float, default=0.1)
     ap.add_argument("--humanize-timing", type=float, default=0.0)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,8 @@
+music21
+numpy
+scipy
+pretty_midi
+pytest
+scikit-learn
+librosa
+setuptools

--- a/streamlit_app/gui.py
+++ b/streamlit_app/gui.py
@@ -4,6 +4,7 @@ import tempfile
 from pathlib import Path
 
 import streamlit as st
+import random
 
 from utilities import groove_sampler_ngram
 from utilities import groove_sampler_rnn
@@ -24,6 +25,9 @@ def main() -> None:
     temp = st.slider("Temperature", 0.0, 1.5, 1.0)
     human_timing = st.slider("Timing Humanization", 0.0, 1.0, 0.0)
     human_velocity = st.slider("Velocity Humanization", 0.0, 1.0, 0.0)
+    seed_input = st.text_input("Random Seed (optional)")
+    if seed_input:
+        random.seed(int(seed_input))
     file = st.file_uploader("Model", type=["pkl", "pt"])
     if st.button("Generate") and file is not None:
         path = Path(file.name)

--- a/tests/test_timing_corrector.py
+++ b/tests/test_timing_corrector.py
@@ -12,6 +12,7 @@ def test_timing_corrector_reduces_jitter() -> None:
         part.insert(o, n)
     tc = TimingCorrector(alpha=0.5)
     corrected = tc.correct_part(part)
+    assert corrected.notes[0].offset == offsets[0]
     orig_res = [o - round(o) for o in offsets]
     new_res = [n.offset - round(n.offset) for n in corrected.notes]
     assert statistics.pstdev(new_res) < statistics.pstdev(orig_res)

--- a/tests/test_velocity_histogram.py
+++ b/tests/test_velocity_histogram.py
@@ -16,3 +16,21 @@ def test_velocity_histogram_sampling() -> None:
     count_90 = vels.count(90)
     ratio = count_90 / len(vels)
     assert 0.5 < ratio < 0.9
+
+
+def test_velocity_histogram_reproducible() -> None:
+    part = stream.Part()
+    for i in range(10):
+        n = note.Note('C4', quarterLength=1.0)
+        n.offset = i
+        part.insert(i, n)
+    hist = {90: 0.7, 110: 0.3}
+    import copy
+    part2 = copy.deepcopy(part)
+    random.seed(42)
+    apply_velocity_histogram(part, hist)
+    vels1 = [n.volume.velocity for n in part.notes]
+    random.seed(42)
+    apply_velocity_histogram(part2, hist)
+    vels2 = [n.volume.velocity for n in part2.notes]
+    assert vels1 == vels2

--- a/utilities/timing_corrector.py
+++ b/utilities/timing_corrector.py
@@ -18,7 +18,7 @@ class TimingCorrector:
         notes = list(new_part.recurse().notes)
         if not notes:
             return new_part
-        ema = 0.0
+        ema = notes[0].offset - round(notes[0].offset)
         for n in notes:
             target = round(n.offset)
             delta = n.offset - target


### PR DESCRIPTION
## Summary
- add requirements-test.txt with packages needed for pytest
- update CI workflow to install from requirements-test.txt
- ensure timing corrector preserves first note offset while smoothing
- include setuptools so tests run cleanly

## Testing
- `pytest tests/test_velocity_histogram.py tests/test_timing_corrector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68644c08c95883289779c7d8131fcf60