### PR TITLE
Add configurable external strum patterns

### DIFF
--- a/.github/workflows/data-ops-smoke.yml
+++ b/.github/workflows/data-ops-smoke.yml
@@ -11,6 +11,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - run: pip install -e .[all]
+      - run: pip install music21
       - run: ruff check data_ops streamlit_app_v2.py tests/test_auto_tag.py tests/test_augment.py tests/test_gui_import.py
       - run: mypy data_ops streamlit_app_v2.py tests/test_auto_tag.py tests/test_augment.py tests/test_gui_import.py --strict
       - run: pytest -m "data_ops or gui" -q

--- a/.github/workflows/packaging-smoke.yml
+++ b/.github/workflows/packaging-smoke.yml
@@ -16,6 +16,7 @@ jobs:
           cache: 'pip'
       - run: pip install build mkdocs mkdocs-material mkdocstrings[python]
       - run: pip install -e .[dev]
+      - run: pip install music21
       - run: python -m build --wheel
       - run: mkdocs build --strict
       - run: pytest tests/test_wheel_import.py tests/test_docs_build.py -q

--- a/generator/guitar_generator.py
+++ b/generator/guitar_generator.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Optional, Tuple, Any, Sequence, Union, cast
 import copy
 from pathlib import Path
 import yaml
+import json
 
 import music21.stream as stream
 import music21.note as note
@@ -170,9 +171,11 @@ class GuitarGenerator(BasePartGenerator):
         tuning: Optional[List[int]] = None,
         timing_variation: float = 0.0,
         gate_length_variation: float = 0.0,
+        external_patterns_path: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        self.external_patterns_path = external_patterns_path
         self.tuning = tuning if tuning is not None else STANDARD_TUNING_OFFSETS
         self.timing_variation = timing_variation
         self.gate_length_variation = gate_length_variation
@@ -204,7 +207,8 @@ class GuitarGenerator(BasePartGenerator):
                 "description": "Failsafe default quarter note strum",
             }
 
-        self._load_external_strum_patterns()
+        if self.external_patterns_path:
+            self._load_external_strum_patterns()
 
     def compose(self, *args, **kwargs):
         result = super().compose(*args, **kwargs)
@@ -789,13 +793,24 @@ class GuitarGenerator(BasePartGenerator):
                     f.write(f"{name}\t{el.duration.quarterLength}\n")
 
     def _load_external_strum_patterns(self) -> None:
-        root = Path(__file__).resolve().parents[1]
-        path = root / "strum_patterns.yml"
+        """Load additional strum patterns from an external YAML or JSON file."""
+        if not self.external_patterns_path:
+            return
+        path = Path(self.external_patterns_path)
         if not path.exists():
             return
         try:
-            with path.open("r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
+            text = path.read_text(encoding="utf-8")
+            data: dict | None = None
+            if path.suffix.lower() in {".yaml", ".yml"}:
+                data = yaml.safe_load(text)
+            elif path.suffix.lower() == ".json":
+                data = json.loads(text)
+            else:
+                try:
+                    data = yaml.safe_load(text)
+                except Exception:
+                    data = json.loads(text)
             if isinstance(data, dict):
                 self.part_parameters.update(data)
         except Exception as e:

--- a/tests/test_guitar_generator.py
+++ b/tests/test_guitar_generator.py
@@ -19,23 +19,21 @@ def _basic_section():
 
 
 def test_load_external_patterns(tmp_path, monkeypatch):
-    root = Path(__file__).resolve().parents[1]
     data = {"extra_pattern": {"pattern": [{"offset": 0.0, "duration": 1.0}]}}
-    file = root / "strum_patterns.yml"
+    file = tmp_path / "patterns.yml"
     file.write_text(yaml.safe_dump(data))
-    try:
-        gen = GuitarGenerator(
-            global_settings={},
-            default_instrument=instrument.Guitar(),
-            part_name="guitar",
-            global_tempo=120,
-            global_time_signature="4/4",
-            global_key_signature_tonic="C",
-            global_key_signature_mode="major",
-        )
-        assert "extra_pattern" in gen.part_parameters
-    finally:
-        file.unlink()
+
+    gen = GuitarGenerator(
+        global_settings={},
+        default_instrument=instrument.Guitar(),
+        part_name="guitar",
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        external_patterns_path=str(file),
+    )
+    assert "extra_pattern" in gen.part_parameters
 
 
 def test_timing_variation_jitter():


### PR DESCRIPTION
## Summary
- allow specifying `external_patterns_path` when creating `GuitarGenerator`
- load external patterns only when the path is provided
- parse YAML or JSON and merge into existing patterns
- adjust test to provide file path for external strum patterns
- ensure music21 is installed in smoke test workflows

## Testing
- `pytest -k guitar_generator::test_load_external_patterns -vv` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_686471a433dc83289f48825e75e151cc