### PR TITLE
Add MIDI recording and preset manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ Launch the Streamlit GUI to compare:
 ```bash
 modcompose gui
 ```
+Refer to [docs/gui.md](docs/gui.md) for the new MIDI capture and preset features.
 
 ### RNN Backend and Live Playback
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,0 +1,25 @@
+# GUI Editor and Presets
+
+The Streamlit GUI now exposes a simple preset system and supports live MIDI capture.
+
+## Recording MIDI
+
+1. Click **Record** to open a virtual MIDI input.
+2. Perform on your controller and hit **Stop** when done.
+3. The captured notes are previewed instantly.
+
+## Presets
+
+Presets are stored under `~/.otokotoba/presets/` as YAML files. Use the sidebar to save or load presets, or manage them via the CLI:
+
+```bash
+modcompose preset list
+modcompose preset export my_preset --out preset.yaml
+modcompose preset import preset.yaml
+```
+
+Apply a preset when rendering a drum pattern:
+
+```bash
+modcompose render spec.yml --preset my_preset
+```

--- a/modular_composer/cli.py
+++ b/modular_composer/cli.py
@@ -8,6 +8,7 @@ import importlib.metadata as _md
 import json
 import random
 import pickle
+import yaml
 import tempfile
 from pathlib import Path
 from types import ModuleType
@@ -189,6 +190,45 @@ except _md.PackageNotFoundError:
     __version__ = "0.0.0"
 
 
+@cli.group()
+def preset() -> None:
+    """Preset management commands."""
+
+
+@preset.command("list")
+def preset_list() -> None:
+    from utilities import preset_manager
+
+    for name in preset_manager.list_presets():
+        click.echo(name)
+
+
+@preset.command("export")
+@click.argument("name")
+@click.option("--out", type=Path, required=True)
+def preset_export(name: str, out: Path) -> None:
+    from utilities import preset_manager
+    data = preset_manager.load_preset(name)
+    if out.suffix.lower() in {".yml", ".yaml"}:
+        yaml.safe_dump(data, out.open("w", encoding="utf-8"))
+    else:
+        json.dump(data, out.open("w", encoding="utf-8"))
+
+
+@preset.command("import")
+@click.argument("file", type=Path)
+@click.option("--name", type=str, default=None)
+def preset_import(file: Path, name: str | None) -> None:
+    from utilities import preset_manager
+
+    with file.open("r", encoding="utf-8") as fh:
+        if file.suffix.lower() in {".yml", ".yaml"}:
+            cfg = yaml.safe_load(fh) or {}
+        else:
+            cfg = json.load(fh)
+    preset_manager.save_preset(name or file.stem, cfg)
+
+
 @cli.command("live")
 @click.argument("model", type=Path)
 @click.option(
@@ -343,6 +383,7 @@ def _cmd_render(args: list[str]) -> None:
     ap.add_argument("--ema-alpha", type=float, default=0.1)
     ap.add_argument("--humanize-timing", type=float, default=0.0)
     ap.add_argument("--humanize-velocity", type=float, default=0.0)
+    ap.add_argument("--preset", type=str, default=None)
     ns = ap.parse_args(args)
 
     if ns.spec.suffix.lower() in {".yml", ".yaml"}:
@@ -353,6 +394,12 @@ def _cmd_render(args: list[str]) -> None:
     else:
         with ns.spec.open("r", encoding="utf-8") as fh:
             spec = json.load(fh)
+
+    if ns.preset:
+        from utilities import preset_manager
+
+        preset_cfg = preset_manager.load_preset(ns.preset)
+        spec.update(preset_cfg)
 
     tempo_curve = spec.get("tempo_curve", [])
     events = spec.get("drum_pattern", [])

--- a/streamlit_app/gui.py
+++ b/streamlit_app/gui.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+import random
 
 import streamlit as st
-import random
 
 from utilities import groove_sampler_ngram
 from utilities import groove_sampler_rnn
+from utilities.midi_capture import MIDIRecorder
+from utilities import preset_manager
 
 
 def _to_midi(events: list[groove_sampler_ngram.Event]) -> bytes:
@@ -29,6 +31,36 @@ def main() -> None:
     if seed_input:
         random.seed(int(seed_input))
     file = st.file_uploader("Model", type=["pkl", "pt"])
+
+    if "preset_names" not in st.session_state:
+        st.session_state["preset_names"] = preset_manager.list_presets()
+    with st.sidebar.expander("Presets", expanded=False):
+        if st.button("Refresh Presets"):
+            st.session_state["preset_names"] = preset_manager.list_presets()
+        selected = st.selectbox("Load", [""] + st.session_state["preset_names"])
+        if selected:
+            cfg = preset_manager.load_preset(selected)
+            bars = cfg.get("bars", bars)
+            temp = cfg.get("temp", temp)
+        name = st.text_input("Preset Name")
+        if st.button("Save Preset"):
+            preset_manager.save_preset(name, {"bars": bars, "temp": temp})
+
+    if "recorder" not in st.session_state:
+        st.session_state["recorder"] = None
+
+    col1, col2 = st.columns(2)
+    if col1.button("Record"):
+        st.session_state["recorder"] = MIDIRecorder()
+        st.session_state["recorder"].start_recording()
+    if col2.button("Stop") and st.session_state["recorder"]:
+        part = st.session_state["recorder"].stop_recording()
+        tmp = Path(tempfile.mkstemp(suffix=".mid")[1])
+        part.write("midi", fp=str(tmp))
+        st.audio(tmp.read_bytes(), format="audio/midi")
+        tmp.unlink()
+        st.session_state["recorder"] = None
+
     if st.button("Generate") and file is not None:
         path = Path(file.name)
         path.write_bytes(file.getbuffer())

--- a/tests/test_midi_capture.py
+++ b/tests/test_midi_capture.py
@@ -1,0 +1,51 @@
+import types
+import pytest
+from music21 import note
+
+from utilities import midi_capture
+
+
+class DummyMidiIn:
+    def __init__(self):
+        self.callback = None
+        self.events = []
+
+    def get_ports(self):
+        return ["dummy"]
+
+    def open_port(self, idx):
+        assert idx == 0
+
+    def ignore_types(self, sysex=False, timing=False, sensing=False):
+        pass
+
+    def set_callback(self, cb):
+        self.callback = cb
+
+    def cancel_callback(self):
+        self.callback = None
+
+    def emit(self, msg, delta=0.0):
+        if self.callback:
+            self.callback((msg, delta), None)
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    midi = DummyMidiIn()
+    monkeypatch.setattr(midi_capture, "rtmidi", types.SimpleNamespace(MidiIn=lambda: midi))
+    rec = midi_capture.MIDIRecorder("dummy", bpm=120.0)
+    rec.start_recording()
+    midi.emit([0x90, 60, 100], 0.0)
+    midi.emit([0x80, 60, 0], 0.5)
+    return rec, midi
+
+
+def test_midi_recorder_basic(recorder):
+    rec, midi = recorder
+    part = rec.stop_recording()
+    notes = list(part.flatten().notes)
+    assert len(notes) == 1
+    n: note.Note = notes[0]
+    assert n.pitch.midi == 60
+    assert abs(n.quarterLength - 1.0) < 0.001

--- a/tests/test_preset_manager.py
+++ b/tests/test_preset_manager.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from utilities import preset_manager
+
+
+def test_preset_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(preset_manager, "PRESET_DIR", tmp_path)
+    cfg = {"bars": 4, "swing": 0.5}
+    preset_manager.save_preset("demo", cfg)
+    assert "demo" in preset_manager.list_presets()
+    loaded = preset_manager.load_preset("demo")
+    assert loaded == cfg

--- a/utilities/midi_capture.py
+++ b/utilities/midi_capture.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import time
+from typing import Dict, Tuple
+
+from music21 import note, stream
+
+try:
+    import rtmidi
+except Exception:  # pragma: no cover - optional
+    rtmidi = None  # type: ignore
+
+
+class MIDIRecorder:
+    """Simple real-time MIDI input recorder."""
+
+    def __init__(self, port_name: str | None = None, *, bpm: float = 120.0) -> None:
+        if rtmidi is None:
+            raise RuntimeError("python-rtmidi required")
+        self._midi = rtmidi.MidiIn()
+        ports = self._midi.get_ports()
+        if port_name is None:
+            if not ports:
+                raise RuntimeError("No MIDI input ports")
+            self.port_name = ports[0]
+        else:
+            if port_name not in ports:
+                raise RuntimeError(f"Port '{port_name}' not found")
+            self.port_name = port_name
+        self._midi.open_port(ports.index(self.port_name))
+        self._midi.ignore_types(sysex=False, timing=False, sensing=False)
+        self.bpm = bpm
+        self._events: list[Tuple[float, list[int]]] = []
+        self._recording = False
+        self._last_time = 0.0
+        self._start_time = 0.0
+
+    def _callback(self, event: Tuple[list[int], float], _data: object | None = None) -> None:
+        if not self._recording:
+            return
+        msg, delta = event
+        self._last_time += float(delta)
+        timestamp = self._last_time
+        self._events.append((timestamp, list(msg)))
+
+    def start_recording(self) -> None:
+        """Begin capturing MIDI events."""
+        self._events.clear()
+        self._recording = True
+        self._last_time = 0.0
+        self._start_time = time.time()
+        self._midi.set_callback(self._callback)
+
+    def stop_recording(self) -> stream.Part:
+        """Stop capture and return a :class:`music21.stream.Part`."""
+        self._recording = False
+        self._midi.cancel_callback()
+        events = list(self._events)
+        self._events.clear()
+        part = stream.Part()
+        beat = 60.0 / self.bpm
+        active: Dict[int, Tuple[float, int]] = {}
+        for ts, msg in events:
+            status = msg[0] & 0xF0
+            if status == 0x90 and msg[2] > 0:
+                active[msg[1]] = (ts, msg[2])
+            elif status in (0x80, 0x90) and msg[2] == 0 or status == 0x80:
+                if msg[1] in active:
+                    start, vel = active.pop(msg[1])
+                    dur = ts - start
+                    n = note.Note(midi=msg[1], quarterLength=dur / beat)
+                    n.volume.velocity = vel
+                    part.insert(start / beat, n)
+        # close remaining notes
+        for pitch, (start, vel) in active.items():
+            dur = self._last_time - start
+            n = note.Note(midi=pitch, quarterLength=dur / beat)
+            n.volume.velocity = vel
+            part.insert(start / beat, n)
+        return part

--- a/utilities/preset_manager.py
+++ b/utilities/preset_manager.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PRESET_DIR = Path.home() / ".otokotoba" / "presets"
+
+
+def _ensure_dir() -> None:
+    PRESET_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _preset_path(name: str) -> Path:
+    return PRESET_DIR / f"{name}.yml"
+
+
+def list_presets() -> list[str]:
+    """Return available preset names."""
+    _ensure_dir()
+    return sorted(p.stem for p in PRESET_DIR.glob("*.yml"))
+
+
+def load_preset(name: str) -> dict[str, Any]:
+    """Load preset ``name`` and return the configuration."""
+    path = _preset_path(name)
+    if not path.exists():
+        raise FileNotFoundError(f"Preset '{name}' not found")
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def save_preset(name: str, config: dict[str, Any]) -> None:
+    """Save ``config`` under ``name``."""
+    _ensure_dir()
+    path = _preset_path(name)
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(config, fh)


### PR DESCRIPTION
## Summary
- implement `MIDIRecorder` for capturing live input
- manage reusable configuration via `preset_manager`
- expose preset subcommands in CLI
- extend Streamlit GUI with recording and preset panel
- document new features and provide tests

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864851754d48328acc91655e212f01c