### PR TITLE
Add format option to export_tab

### DIFF
--- a/generator/guitar_generator.py
+++ b/generator/guitar_generator.py
@@ -776,14 +776,44 @@ class GuitarGenerator(BasePartGenerator):
         score.insert(0, self._last_part)
         score.write("musicxml", fp=path)
 
-    def export_tab(self, path: str) -> None:
-        """Export the last generated guitar part as tablature."""
+    def export_tab(self, path: str, format: str = "xml") -> None:
+        """Export the last generated guitar part as tablature.
+
+        Parameters
+        ----------
+        path:
+            Destination file path.
+        format:
+            Either ``"xml"`` for MusicXML output or ``"ascii"`` for a text
+            representation. Defaults to ``"xml"``.
+        """
+
         if not hasattr(self, "_last_part") or self._last_part is None:
             raise RuntimeError("No part generated yet")
-        try:
-            self._last_part.write("lilypond", fp=path)
-        except Exception:
-            # Fallback: simple ASCII tab (pitch or chord pitches and duration)
+
+        if format == "xml":
+            try:
+                from music21 import tab  # type: ignore
+                TabContainer = getattr(tab, "TabStaff", None) or getattr(tab, "TabStream", None)
+            except Exception:
+                TabContainer = None
+
+            try:
+                if TabContainer is not None:
+                    tab_stream = TabContainer()
+                    tab_stream.append(self._last_part.flat)
+                    score = stream.Score()
+                    score.insert(0, tab_stream)
+                else:
+                    score = stream.Score()
+                    score.insert(0, self._last_part)
+                score.write("musicxml", fp=path)
+                return
+            except Exception:
+                # Fall back to ASCII if XML export fails
+                format = "ascii"
+
+        if format == "ascii":
             with open(path, "w", encoding="utf-8") as f:
                 for el in self._last_part.flatten().notes:
                     if hasattr(el, "pitch"):
@@ -791,6 +821,10 @@ class GuitarGenerator(BasePartGenerator):
                     else:
                         name = "+".join(p.nameWithOctave for p in el.pitches)
                     f.write(f"{name}\t{el.duration.quarterLength}\n")
+            return
+
+        if format not in {"xml", "ascii"}:
+            raise ValueError(f"Unsupported format: {format}")
 
     def _load_external_strum_patterns(self) -> None:
         """Load additional strum patterns from an external YAML or JSON file."""

--- a/tests/test_guitar_generator.py
+++ b/tests/test_guitar_generator.py
@@ -100,7 +100,7 @@ def test_export_musicxml(tmp_path):
     assert path.exists() and path.stat().st_size > 0
 
 
-def test_export_tab(tmp_path):
+def test_export_tab_xml_and_ascii(tmp_path):
     gen = GuitarGenerator(
         global_settings={},
         default_instrument=instrument.Guitar(),
@@ -111,9 +111,14 @@ def test_export_tab(tmp_path):
         global_key_signature_mode="major",
     )
     gen.compose(section_data=_basic_section())
-    path = tmp_path / "out.ly"
-    gen.export_tab(str(path))
-    assert path.exists() and path.stat().st_size > 0
+
+    xml_path = tmp_path / "out.xml"
+    gen.export_tab(str(xml_path), format="xml")
+    assert xml_path.exists() and xml_path.stat().st_size > 0
+
+    ascii_path = tmp_path / "out.txt"
+    gen.export_tab(str(ascii_path), format="ascii")
+    assert ascii_path.exists() and ascii_path.stat().st_size > 0
 
 
 def test_gate_length_variation_range():


### PR DESCRIPTION
## Summary
- add format argument to `export_tab` to support `xml` and `ascii`
- fallback to ASCII when MusicXML tablature export fails
- test both XML and ASCII export modes

## Testing
- `pytest tests/test_guitar_generator.py::test_export_tab_xml_and_ascii -q`


------
https://chatgpt.com/codex/tasks/task_e_68648baac7e883289e258d4cc994e7a9