### PR TITLE
Add tuning presets and CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ Use `--strict-drum-map` if unknown drum instrument names should raise an error:
 python modular_composer.py --main-cfg config/main_cfg.yml --strict-drum-map
 ```
 
+You can override the guitar tuning directly from the CLI. Specify one of the
+presets (`standard`, `drop_d`, `open_g`) or provide six comma-separated semitone
+offsets:
+
+```bash
+python modular_composer.py --main-cfg config/main_cfg.yml --tuning drop_d
+python modular_composer.py --main-cfg config/main_cfg.yml --tuning 0,-2,0,0,0,0
+```
+
+This overrides `part_defaults.guitar.tuning` in your configuration.
+
 The same behaviour can be enabled with `global_settings.strict_drum_map: true` in your configuration file.
 
 ベロシティフェードがフィル前の何拍に及ぶかを制御できます:

--- a/generator/guitar_generator.py
+++ b/generator/guitar_generator.py
@@ -80,6 +80,13 @@ DEFAULT_GUITAR_OCTAVE_RANGE: Tuple[int, int] = (2, 5)
 GUITAR_STRUM_DELAY_QL: float = 0.02
 STANDARD_TUNING_OFFSETS = [0, 0, 0, 0, 0, 0]
 
+# User-friendly tuning presets (semitone offsets per string)
+TUNING_PRESETS: Dict[str, List[int]] = {
+    "standard": STANDARD_TUNING_OFFSETS,
+    "drop_d": [-2, 0, 0, 0, 0, 0],
+    "open_g": [-2, -2, 0, 0, 0, -2],
+}
+
 EXEC_STYLE_BLOCK_CHORD = "block_chord"
 EXEC_STYLE_STRUM_BASIC = "strum_basic"
 EXEC_STYLE_ARPEGGIO_FROM_INDICES = "arpeggio_from_indices"
@@ -168,7 +175,7 @@ class GuitarGenerator(BasePartGenerator):
     def __init__(
         self,
         *args,
-        tuning: Optional[List[int]] = None,
+        tuning: Optional[Union[str, Sequence[int]]] = None,
         timing_variation: float = 0.0,
         gate_length_variation: float = 0.0,
         external_patterns_path: Optional[str] = None,
@@ -176,7 +183,14 @@ class GuitarGenerator(BasePartGenerator):
     ):
         super().__init__(*args, **kwargs)
         self.external_patterns_path = external_patterns_path
-        self.tuning = tuning if tuning is not None else STANDARD_TUNING_OFFSETS
+        if isinstance(tuning, str):
+            self.tuning = TUNING_PRESETS.get(tuning.lower(), STANDARD_TUNING_OFFSETS)
+        elif tuning is None:
+            self.tuning = STANDARD_TUNING_OFFSETS
+        else:
+            if len(tuning) != 6:
+                raise ValueError("tuning must be length 6")
+            self.tuning = [int(x) for x in tuning]
         self.timing_variation = timing_variation
         self.gate_length_variation = gate_length_variation
         from utilities.core_music_utils import get_time_signature_object

--- a/tests/test_cli_tuning.py
+++ b/tests/test_cli_tuning.py
@@ -1,0 +1,72 @@
+import sys
+from pathlib import Path
+import yaml
+from music21 import stream
+import modular_composer
+from utilities.generator_factory import GenFactory
+
+
+def _write_cfg(tmp_path: Path) -> Path:
+    chordmap = {
+        'sections': {
+            'A': {
+                'processed_chord_events': [
+                    {
+                        'absolute_offset_beats': 0.0,
+                        'humanized_duration_beats': 4.0,
+                        'chord_symbol_for_voicing': 'C',
+                    }
+                ],
+                'musical_intent': {'emotion': 'neutral'},
+                'expression_details': {},
+            }
+        }
+    }
+    cm_path = tmp_path / "cm.yml"
+    cm_path.write_text(yaml.safe_dump(chordmap))
+    cfg = {
+        'global_settings': {
+            'time_signature': '4/4',
+            'tempo_bpm': 120,
+            'key_tonic': 'C',
+            'key_mode': 'major',
+        },
+        'sections_to_generate': ['A'],
+        'paths': {
+            'chordmap_path': str(cm_path),
+            'rhythm_library_path': str(Path('data/rhythm_library.yml').resolve()),
+            'output_dir': str(tmp_path),
+        },
+        'part_defaults': {'guitar': {}, 'rhythm': {}},
+    }
+    cfg_path = tmp_path / "cfg.yml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    return cfg_path
+
+
+def _run_cli(tmp_path: Path, tuning_value, monkeypatch):
+    cfg_path = _write_cfg(tmp_path)
+    captured = {}
+
+    def fake_build_from_config(cfg, rl, tempo_map=None):
+        captured['cfg'] = cfg
+        return {}
+
+    monkeypatch.setattr(GenFactory, 'build_from_config', fake_build_from_config)
+    monkeypatch.setattr(modular_composer, 'compose', lambda *a, **k: (stream.Score(), []))
+    monkeypatch.setattr(stream.Score, 'write', lambda self, fmt, fp: None)
+
+    argv = ['modcompose', '--main-cfg', str(cfg_path), '--tuning', tuning_value, '--dry-run']
+    monkeypatch.setattr(sys, 'argv', argv)
+    modular_composer.main_cli()
+    return captured['cfg']['part_defaults']['guitar']['tuning']
+
+
+def test_cli_tuning_preset(tmp_path, monkeypatch):
+    val = _run_cli(tmp_path, 'drop_d', monkeypatch)
+    assert val == 'drop_d'
+
+
+def test_cli_tuning_offsets(tmp_path, monkeypatch):
+    val = _run_cli(tmp_path, '0,-2,0,0,0,0', monkeypatch)
+    assert val == [0, -2, 0, 0, 0, 0]

--- a/tests/test_guitar_generator.py
+++ b/tests/test_guitar_generator.py
@@ -84,6 +84,33 @@ def test_custom_tuning_applied():
     assert int(p_drop.ps - p_std.ps) == -2
 
 
+def test_tuning_preset_drop_d():
+    gen = GuitarGenerator(
+        global_settings={},
+        default_instrument=instrument.Guitar(),
+        part_name="g3",
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        tuning="drop_d",
+    )
+    assert gen.tuning == [-2, 0, 0, 0, 0, 0]
+    gen_std = GuitarGenerator(
+        global_settings={},
+        default_instrument=instrument.Guitar(),
+        part_name="g4",
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        tuning="standard",
+    )
+    p_std = gen_std._get_guitar_friendly_voicing(harmony.ChordSymbol("E"), 1)[0]
+    p_drop = gen._get_guitar_friendly_voicing(harmony.ChordSymbol("E"), 1)[0]
+    assert int(p_drop.ps - p_std.ps) == -2
+
+
 def test_export_musicxml(tmp_path):
     gen = GuitarGenerator(
         global_settings={},


### PR DESCRIPTION
## Summary
- add `_parse_tuning` helper and update argument parser
- document tuning presets with examples in README
- test CLI tuning for preset and offsets

## Testing
- `python -m py_compile generator/guitar_generator.py modular_composer.py tests/test_guitar_generator.py tests/test_cli_tuning.py`
- `pytest tests/test_guitar_generator.py tests/test_cli_tuning.py tests/test_cli_info.py::test_root_cli_info tests/test_compose_part_streams.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6864ac081af883289515b956ce3c6a95