### PR TITLE
Add transformer AI module and interactive CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,18 @@ Sample with:
 modcompose rnn sample model.pt -l 4 > pattern.json
 ```
 
+## AI Transformer Backend
+
+Install `transformers` to experiment with a language-model driven bass line
+generator. Pass `--ai-backend transformer` and specify the model name:
+
+```bash
+modcompose live model.pkl --ai-backend transformer --model-name gpt2-music
+```
+
+Historical generation data can guide future runs when `--use-history` is set.
+See [docs/ai.md](docs/ai.md) for details.
+
 ## Realtime Low-Latency
 
 Live playback uses a double-buffered engine. Synchronise with external MIDI

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -1,0 +1,30 @@
+# AI Features
+
+This project optionally integrates a Transformer-based bass generator via
+Hugging Face Transformers.
+
+## Usage
+
+Install the dependency:
+
+```bash
+pip install transformers
+```
+
+Generate with the new backend:
+
+```bash
+modcompose live model.pkl --ai-backend transformer --model-name gpt2-music
+```
+
+Enable feedback from previous sessions with `--use-history`. Generation
+statistics are stored in `~/.modcompose_history.json` and loaded on start.
+
+For real-time interaction use the interactive mode:
+
+```bash
+modcompose interact --backend transformer --bpm 120
+```
+
+Incoming MIDI notes trigger the `TransformerBassGenerator` and forward events to
+the selected MIDI output.

--- a/tests/test_ai_sampler.py
+++ b/tests/test_ai_sampler.py
@@ -1,0 +1,19 @@
+import json
+from utilities import ai_sampler
+
+
+def test_transformer_bass_generate(monkeypatch):
+    calls = {}
+
+    class DummyPipe:
+        def __call__(self, prompt, max_new_tokens=64, num_return_sequences=1):
+            calls['prompt'] = prompt
+            return [{"generated_text": prompt + json.dumps([{"instrument": "bass"}])}]
+
+    monkeypatch.setattr(ai_sampler, "pipeline", lambda *a, **k: DummyPipe())
+    monkeypatch.setattr(ai_sampler, "AutoModelForCausalLM", type("M", (), {"from_pretrained": lambda *a, **k: object()}) )
+    monkeypatch.setattr(ai_sampler, "AutoTokenizer", type("T", (), {"from_pretrained": lambda *a, **k: object()}) )
+    gen = ai_sampler.TransformerBassGenerator(model_name="dummy")
+    events = gen.generate([], 1)
+    assert events == [{"instrument": "bass"}]
+    assert "events" in calls["prompt"]

--- a/tests/test_gui_interactive.py
+++ b/tests/test_gui_interactive.py
@@ -1,0 +1,24 @@
+import pytest
+
+pytest.importorskip("streamlit", reason="GUI deps not installed in CI")
+
+from streamlit_app import gui
+
+
+def test_setup_interactive(monkeypatch):
+    logs = []
+
+    class DummyEngine:
+        def __init__(self, model_name: str, bpm: float) -> None:
+            self.args = (model_name, bpm)
+            self.cbs = []
+
+        def add_callback(self, cb):
+            self.cbs.append(cb)
+
+    monkeypatch.setattr(gui, "InteractiveEngine", DummyEngine)
+    engine = gui.setup_interactive("m", 120.0, lambda msg: logs.append(msg))
+    assert isinstance(engine, DummyEngine)
+    assert engine.cbs
+    engine.cbs[0]({"note": 60})
+    assert logs

--- a/tests/test_interactive_engine.py
+++ b/tests/test_interactive_engine.py
@@ -1,0 +1,24 @@
+from utilities import interactive_engine
+
+
+class Msg:
+    type = "note_on"
+    note = 60
+    velocity = 100
+
+
+def test_interactive_trigger(monkeypatch):
+    events = []
+
+    class DummyGen:
+        def generate(self, prompt, bars):
+            events.append(prompt)
+            return [{"instrument": "bass"}]
+
+    monkeypatch.setattr(interactive_engine, "TransformerBassGenerator", lambda name: DummyGen())
+    eng = interactive_engine.InteractiveEngine(model_name="x")
+    out = []
+    eng.add_callback(lambda ev: out.append(ev))
+    eng._trigger(Msg())
+    assert out == [{"instrument": "bass"}]
+    assert events

--- a/tests/test_user_history.py
+++ b/tests/test_user_history.py
@@ -1,0 +1,12 @@
+import json
+from utilities import user_history
+
+
+def test_record_and_load(tmp_path, monkeypatch):
+    hist_file = tmp_path / "hist.json"
+    monkeypatch.setattr(user_history, "_HISTORY_FILE", hist_file)
+    user_history.record_generate({"bpm": 120}, [{"instrument": "bass"}])
+    data = json.loads(hist_file.read_text())
+    assert data[0]["config"]["bpm"] == 120
+    loaded = user_history.load_history()
+    assert loaded == data

--- a/utilities/ai_sampler.py
+++ b/utilities/ai_sampler.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from typing import List, Dict
+
+try:
+    from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+except Exception:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None  # type: ignore
+    AutoTokenizer = None  # type: ignore
+    pipeline = None  # type: ignore
+
+
+class TransformerBassGenerator:
+    """Generate bass events using a Transformer model."""
+
+    def __init__(self, model_name: str = "gpt2-music") -> None:
+        if AutoModelForCausalLM is None:
+            raise RuntimeError("transformers package required")
+        self.model_name = model_name
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForCausalLM.from_pretrained(model_name)
+        self.pipe = pipeline("text-generation", model=self.model, tokenizer=self.tokenizer)
+
+    def _parse_events(self, text: str) -> List[Dict]:
+        try:
+            data = json.loads(text)
+            if isinstance(data, list):
+                return [dict(ev) for ev in data]
+        except Exception:
+            pass
+        return []
+
+    def generate(self, prompt_events: List[Dict], bars: int) -> List[Dict]:
+        prompt = json.dumps({"events": prompt_events, "bars": bars})
+        out = self.pipe(prompt, max_new_tokens=64, num_return_sequences=1)[0]["generated_text"]
+        generated = out[len(prompt) :].strip()
+        return self._parse_events(generated)
+
+__all__ = ["TransformerBassGenerator"]

--- a/utilities/interactive_engine.py
+++ b/utilities/interactive_engine.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+import warnings
+
+try:
+    import mido
+except Exception as e:  # pragma: no cover - optional
+    mido = None  # type: ignore
+    _MIDO_ERROR = e
+else:
+    _MIDO_ERROR = None
+
+from .ai_sampler import TransformerBassGenerator
+
+
+class InteractiveEngine:
+    """Trigger bass generation on incoming MIDI events."""
+
+    def __init__(self, model_name: str = "gpt2-music", bpm: float = 120.0) -> None:
+        self.generator = TransformerBassGenerator(model_name)
+        self.bpm = bpm
+        self.callbacks: list[Callable[[dict], None]] = []
+
+    def add_callback(self, callback: Callable[[dict], None]) -> None:
+        self.callbacks.append(callback)
+
+    def _trigger(self, msg: Any) -> None:
+        if msg.type == "note_on" and msg.velocity > 0:
+            events = self.generator.generate([
+                {"pitch": msg.note, "velocity": msg.velocity}
+            ], 1)
+            for cb in self.callbacks:
+                for ev in events:
+                    cb(ev)
+
+    def run(self) -> None:
+        if mido is None:
+            raise RuntimeError(f"mido unavailable: {_MIDO_ERROR}")
+        names = mido.get_input_names()
+        if not names:
+            warnings.warn("No MIDI input ports available", RuntimeWarning)
+            return
+        with mido.open_input(names[0]) as port:
+            for msg in port:
+                self._trigger(msg)
+
+__all__ = ["InteractiveEngine"]

--- a/utilities/user_history.py
+++ b/utilities/user_history.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_HISTORY_FILE = Path.home() / ".modcompose_history.json"
+
+
+def record_generate(config: dict, events: list[dict]) -> None:
+    history = load_history()
+    history.append({"config": config, "events": events})
+    with _HISTORY_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(history, fh)
+
+
+def load_history() -> list[dict]:
+    if _HISTORY_FILE.exists():
+        try:
+            with _HISTORY_FILE.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except Exception:
+            return []
+    return []
+
+__all__ = ["record_generate", "load_history"]


### PR DESCRIPTION
## Summary
- add `TransformerBassGenerator` and user history utilities
- add interactive MIDI engine and CLI command
- support transformer backend options in `modcompose live`
- document AI features and usage
- integrate interactive mode into Streamlit GUI
- test new modules including GUI interactive setup

## Testing
- `pytest tests/test_ai_sampler.py tests/test_user_history.py tests/test_interactive_engine.py tests/test_gui_interactive.py -q`
- `mypy`
- `ruff check streamlit_app/gui.py tests/test_gui_interactive.py`
- `pytest -q` *(fails: missing heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68651381c9ac83288223143e45cfa8cb