### PR TITLE
Refine guitar expression features

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ though the notes are correct. You can switch mappings programmatically via
 | II–V build-up         | `approach_style_on_4th`   | `approach_style_on_4th: subdom_dom`              |
 | Velocity envelope     | `velocity_envelope`       | `velocity_envelope: [[0.0,60],[2.0,90]]`         |
 
+## Advanced Guitar Features
+
+| Feature | Parameter | Effect |
+|---------|-----------|--------|
+| Stroke direction | `stroke_direction` | `"down"` multiplies velocity by 1.1, `"up"` by 0.9 |
+| Palm mute | `palm_mute` | Shortens sustain by 15% and lowers velocity |
+| Slide timing | `slide_in_offset`, `slide_out_offset` | Fractional offsets (0.0–1.0) describing portamento start and end |
+| Fret bend | `bend_amount`, `bend_release_offset` | Bend depth in semitones and release position before note end |
+
 ## Humanize – intensity envelope / swing override
 
 Velocity scaling now follows each section’s `musical_intent.intensity`.

--- a/docs/arrangement_features.md
+++ b/docs/arrangement_features.md
@@ -80,3 +80,15 @@ global_settings:
 
 Override the setting from the command line with `--consonant-sync-mode` when
 running `modular_composer.py`.
+
+## Guitar Expression Parameters
+
+The guitar generator supports several parameters for expressive playing:
+
+- `stroke_direction`: set to `"down"` or `"up"` to bias velocity 10% higher or
+  lower respectively.
+- `palm_mute`: when `true` notes shorten by 15% and velocity drops 15%.
+- `slide_in_offset` / `slide_out_offset`: fractional offsets from 0.0‑1.0
+  indicating where portamento begins and ends.
+- `bend_amount`: depth of a fret bend in semitones.
+- `bend_release_offset`: point before the note end when a bend releases.


### PR DESCRIPTION
## Summary
- import `music21.chord` in tests
- safely store slide and bend offsets on articulations
- adjust strum velocity scaling for down/up strokes
- allow event `palm_mute` to override block defaults
- document new guitar parameters
- add regression tests for strum velocity

## Testing
- `pytest tests/test_guitar_generator.py::test_slide_offset_params tests/test_guitar_generator.py::test_bend_params tests/test_guitar_generator.py::test_stroke_direction_velocity tests/test_guitar_generator.py::test_palm_mute_shorter_sustain tests/test_guitar_generator.py::test_strum_basic_stroke_velocity tests/test_guitar_generator.py::test_hammer_on_pull_off_basic tests/test_guitar_generator.py::test_hammer_on_pull_off_interval_threshold tests/test_guitar_generator.py::test_hammer_on_pull_off_probability -q`
- `pytest -q` *(fails: ModuleNotFoundError and other missing optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_6865610a934c8328bb26fc34e4eff32b