### PR TITLE
Add interactive engine and articulation mapper

### DIFF
--- a/.github/workflows/groove.yml
+++ b/.github/workflows/groove.yml
@@ -17,7 +17,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - run: sudo apt-get update && sudo apt-get install -y fluid-soundfont-gm
       - run: pip install python-rtmidi
+      - run: pip install soundfile
+      - run: pip install torch --no-cache-dir --index-url https://download.pytorch.org/whl/cpu
       - name: Install test dependencies
         run: pip install -e .[test] -r requirements-test.txt
       - name: build cyext

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It automatically generates chords, melodies and instrumental parts for each chap
 - [Generating MIDI](#generating-midi)
 - [Demo MIDI Generation](#demo-midi-generation)
 - [Notebook Demo](#notebook-demo)
+- [Tone and Dynamics](#tone-and-dynamics)
 
 
 ## Setup
@@ -621,7 +622,8 @@ parameter when using the synchroniser programmatically.
 Generate a simple MIDI file from a YAML or JSON description:
 
 ```bash
-modcompose render spec.yml -o out.mid --soundfont path/to/timgm.sf2
+modcompose render spec.yml -o out.mid --soundfont path/to/timgm.sf2 \
+  --normalize-lufs -14
 ```
 
 ### Golden MIDI Regression
@@ -705,15 +707,30 @@ modcompose rnn sample model.pt -l 4 > pattern.json
 
 ## AI Transformer Backend
 
-Install `transformers` to experiment with a language-model driven bass line
+Install `transformers` and `torch` to experiment with a language-model driven bass line
 generator. Pass `--ai-backend transformer` and specify the model name:
 
 ```bash
-modcompose live model.pkl --ai-backend transformer --model-name gpt2-music
+modcompose live model.pkl --ai-backend transformer --model-name gpt2-medium
 ```
 
 Historical generation data can guide future runs when `--use-history` is set.
 See [docs/ai.md](docs/ai.md) for details.
+
+Interactive usage:
+
+```bash
+modcompose interact --backend transformer --model-name gpt2-medium \
+  --midi-in "Device In" --midi-out "Device Out" --bpm 120
+```
+
+## Tone and Dynamics
+
+Use articulation key switches and amp presets to refine playback. Add
+`--articulation-profile` to `compose` commands to load a YAML mapping.
+Audio rendered with `modcompose render` can be loudness normalised via
+`--normalize-lufs`.
+See [docs/tone.md](docs/tone.md) for details.
 
 ## Realtime Low-Latency
 

--- a/cyext/humanize.pyx
+++ b/cyext/humanize.pyx
@@ -17,7 +17,7 @@ def apply_swing(part_stream, double swing_ratio, int subdiv=8):
         if abs(within - step) < tol:
             n.offset = pair_start + pair * swing_ratio
 
-def humanize_velocities(part_stream, int amount=4):
+def humanize_velocities(part_stream, int amount=4, bint use_expr_cc11=False, bint use_aftertouch=False):
     for n in part_stream.recurse().notes:
         vel = getattr(n.volume, 'velocity', None)
         if vel is None:
@@ -29,6 +29,14 @@ def humanize_velocities(part_stream, int amount=4):
         delta = random.randint(-amount, amount)
         new_vel = max(1, min(127, vel + delta))
         n.volume.velocity = new_vel
+        if use_expr_cc11:
+            if not hasattr(part_stream, "extra_cc"):
+                part_stream.extra_cc = []
+            part_stream.extra_cc.append({"time": float(n.offset), "number": 11, "value": new_vel})
+        if use_aftertouch:
+            if not hasattr(part_stream, "extra_cc"):
+                part_stream.extra_cc = []
+            part_stream.extra_cc.append({"time": float(n.offset), "number": 74, "value": new_vel})
 
 def apply_envelope(part_stream, int start, int end, double scale):
     """Cython-accelerated envelope scaling."""

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -5,25 +5,32 @@ Hugging Face Transformers.
 
 ## Usage
 
-Install the dependency:
+Install the dependencies:
 
 ```bash
-pip install transformers
+pip install transformers torch mido python-rtmidi
 ```
 
 Generate with the new backend:
 
 ```bash
-modcompose live model.pkl --ai-backend transformer --model-name gpt2-music
+modcompose live model.pkl --ai-backend transformer --model-name gpt2-medium
+```
+
+Or produce a short JSON sample:
+
+```bash
+modcompose sample model.pkl --ai-backend transformer --model-name gpt2-medium
 ```
 
 Enable feedback from previous sessions with `--use-history`. Generation
-statistics are stored in `~/.modcompose_history.json` and loaded on start.
+statistics are stored in `~/.otokotoba/history.jsonl` and loaded on start.
 
 For real-time interaction use the interactive mode:
 
 ```bash
-modcompose interact --backend transformer --bpm 120
+modcompose interact --backend transformer --model-name gpt2-medium \
+  --midi-in "Device In" --midi-out "Device Out" --bpm 120
 ```
 
 Incoming MIDI notes trigger the `TransformerBassGenerator` and forward events to

--- a/docs/tone.md
+++ b/docs/tone.md
@@ -1,0 +1,12 @@
+# Tone and Dynamics
+
+This project can shape bass tone via MIDI control changes. The `ToneShaper`
+selects an amp/cabinet preset depending on playing intensity. The chosen preset
+is sent as a CC#31 value at the start of the part.
+
+Key switch notes for articulations can be inserted with
+`add_key_switches()` from `utilities.articulation_mapper`.
+
+Velocity humanisation optionally maps note volumes to expression (CC11) and
+channel aftertouch (CC74). Enable these with the global settings
+`use_expr_cc11` and `use_aftertouch`.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,3 +11,8 @@ types-PyYAML
 hypothesis
 pydantic>=2.7
 setuptools
+mido
+python-rtmidi
+transformers==4.*
+torch==2.*
+soundfile

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,8 @@ if USE_CYTHON:
 if not ext_modules:
     ext_modules = [Extension(f"cyext.{s.split('/')[-1]}", [f"{s}.c"]) for s in SOURCES]
 
-setup(name="cyext", ext_modules=ext_modules)
+try:
+    setup(name="cyext", ext_modules=ext_modules)
+except Exception as exc:  # pragma: no cover - build may fail
+    logging.warning("C extension build failed, using pure Python fallback: %s", exc)
+    setup(name="cyext", ext_modules=[])

--- a/tests/test_ai_sampler.py
+++ b/tests/test_ai_sampler.py
@@ -1,4 +1,5 @@
 import json
+
 from utilities import ai_sampler
 
 
@@ -7,13 +8,22 @@ def test_transformer_bass_generate(monkeypatch):
 
     class DummyPipe:
         def __call__(self, prompt, max_new_tokens=64, num_return_sequences=1):
-            calls['prompt'] = prompt
-            return [{"generated_text": prompt + json.dumps([{"instrument": "bass"}])}]
+            calls["prompt"] = prompt
+            data = [{"instrument": "bass", "i": i} for i in range(8)]
+            return [{"generated_text": prompt + json.dumps(data)}]
 
     monkeypatch.setattr(ai_sampler, "pipeline", lambda *a, **k: DummyPipe())
-    monkeypatch.setattr(ai_sampler, "AutoModelForCausalLM", type("M", (), {"from_pretrained": lambda *a, **k: object()}) )
-    monkeypatch.setattr(ai_sampler, "AutoTokenizer", type("T", (), {"from_pretrained": lambda *a, **k: object()}) )
+    monkeypatch.setattr(
+        ai_sampler,
+        "AutoModelForCausalLM",
+        type("M", (), {"from_pretrained": lambda *a, **k: object()}),
+    )
+    monkeypatch.setattr(
+        ai_sampler,
+        "AutoTokenizer",
+        type("T", (), {"from_pretrained": lambda *a, **k: object()}),
+    )
     gen = ai_sampler.TransformerBassGenerator(model_name="dummy")
-    events = gen.generate([], 1)
-    assert events == [{"instrument": "bass"}]
+    events = gen.generate([], 2)
+    assert len(events) == 8
     assert "events" in calls["prompt"]

--- a/tests/test_articulation_mapper.py
+++ b/tests/test_articulation_mapper.py
@@ -1,0 +1,15 @@
+from music21 import note, stream
+
+from utilities.articulation_mapper import add_key_switches
+
+
+def test_add_key_switches() -> None:
+    part = stream.Part()
+    part.append(note.Note("C2", quarterLength=1.0))
+    part.append(note.Note("D2", quarterLength=1.0))
+
+    add_key_switches(part, {"finger": 28, "slap": 25, "mute": 29})
+    notes = list(part.flatten().notes)
+    assert notes[0].pitch.midi == 28
+    assert notes[0].offset == -2.0
+    assert len(notes) == 3

--- a/tests/test_cli_transformer.py
+++ b/tests/test_cli_transformer.py
@@ -1,0 +1,30 @@
+import json
+
+from modular_composer import cli
+from utilities import ai_sampler, user_history
+
+
+def test_sample_transformer(monkeypatch, tmp_path, capsys):
+    class DummyPipe:
+        def __call__(self, prompt, max_new_tokens=64, num_return_sequences=1):
+            return [{"generated_text": prompt + json.dumps([{"instrument": "bass"}])}]
+
+    monkeypatch.setattr(ai_sampler, "pipeline", lambda *a, **k: DummyPipe())
+    monkeypatch.setattr(
+        ai_sampler,
+        "AutoModelForCausalLM",
+        type("M", (), {"from_pretrained": lambda *a, **k: object()}),
+    )
+    monkeypatch.setattr(
+        ai_sampler,
+        "AutoTokenizer",
+        type("T", (), {"from_pretrained": lambda *a, **k: object()}),
+    )
+    hist_file = tmp_path / "history.jsonl"
+    monkeypatch.setattr(user_history, "_HISTORY_FILE", hist_file)
+
+    model = tmp_path / "dummy.pt"
+    model.write_text("x")
+    cli.main(["sample", str(model), "--ai-backend", "transformer", "--model-name", "dummy"])
+    out = capsys.readouterr().out
+    assert json.loads(out)[0]["instrument"] == "bass"

--- a/tests/test_emotion_arranger.py
+++ b/tests/test_emotion_arranger.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import yaml
+
+from utilities.emotion_arranger import generate_bass_arrangement
+
+
+def test_generate_bass_arrangement(tmp_path: Path) -> None:
+    chordmap = {
+        "global_settings": {
+            "tempo": 100,
+            "time_signature": "4/4",
+            "key_tonic": "C",
+            "key_mode": "major",
+        },
+        "sections": {
+            "Intro": {
+                "order": 1,
+                "length_in_measures": 2,
+                "musical_intent": {
+                    "emotion": "quiet_pain_and_nascent_strength",
+                    "intensity": "low",
+                },
+            }
+        },
+    }
+    chordmap_path = tmp_path / "chordmap.yaml"
+    chordmap_path.write_text(yaml.safe_dump(chordmap))
+
+    arrangement = generate_bass_arrangement(
+        chordmap_path,
+        Path("data/rhythm_library.yml"),
+        Path("data/emotion_profile.yaml"),
+    )
+
+    assert arrangement["Intro"]["bass_pattern_key"] == "root_only"

--- a/tests/test_gui_interactive.py
+++ b/tests/test_gui_interactive.py
@@ -17,7 +17,8 @@ def test_setup_interactive(monkeypatch):
             self.cbs.append(cb)
 
     monkeypatch.setattr(gui, "InteractiveEngine", DummyEngine)
-    engine = gui.setup_interactive("m", 120.0, lambda msg: logs.append(msg))
+    monkeypatch.setattr("utilities.interactive_engine.InteractiveEngine", DummyEngine)
+    engine = gui.setup_interactive("m", 120.0, "in", "out", lambda msg: logs.append(msg))
     assert isinstance(engine, DummyEngine)
     assert engine.cbs
     engine.cbs[0]({"note": 60})

--- a/tests/test_interactive_engine.py
+++ b/tests/test_interactive_engine.py
@@ -22,3 +22,51 @@ def test_interactive_trigger(monkeypatch):
     eng._trigger(Msg())
     assert out == [{"instrument": "bass"}]
     assert events
+
+
+async def _dummy_start(
+    eng: interactive_engine.InteractiveEngine, monkeypatch
+) -> list[str]:
+    sent: list[str] = []
+
+    class Port:
+        def __iter__(self):
+            yield Msg()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def send(self, msg):
+            sent.append(msg.type)
+
+    monkeypatch.setattr(
+        interactive_engine,
+        "mido",
+        type(
+            "M",
+            (),
+            {
+                "open_input": lambda *_a, **_k: Port(),
+                "open_output": lambda *_a, **_k: Port(),
+                "Message": lambda *a, **k: type("Msg", (), {"type": "note_on"})(),
+            },
+        ),
+    )
+    monkeypatch.setattr(interactive_engine, "_MIDO_ERROR", None)
+    await eng.start("in", "out")
+    return sent
+
+
+def test_start_async(monkeypatch):
+    class DummyGen:
+        def generate(self, prompt, bars):
+            return [{"pitch": 60, "velocity": 100, "duration": 0.1}]
+
+    monkeypatch.setattr(interactive_engine, "TransformerBassGenerator", lambda name: DummyGen())
+    eng = interactive_engine.InteractiveEngine(model_name="x")
+
+    sent = __import__("asyncio").run(_dummy_start(eng, monkeypatch))
+    assert "note_on" in sent

--- a/tests/test_loudness_normalizer.py
+++ b/tests/test_loudness_normalizer.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+from utilities.loudness_normalizer import normalize_wav
+
+
+def test_normalize_wav(tmp_path: Path) -> None:
+    sr = 16000
+    t = np.linspace(0, 1.0, sr, endpoint=False)
+    y = 0.5 * np.sin(2 * np.pi * 1000 * t)
+    inp = tmp_path / "in.wav"
+    out = tmp_path / "out.wav"
+    sf.write(inp, y, sr)
+    normalize_wav(inp, out, target_lufs=-20.0)
+    y_norm, _ = sf.read(out)
+    rms = np.sqrt(np.mean(y_norm ** 2))
+    lufs = 20 * np.log10(rms)
+    assert abs(lufs - (-20.0)) < 1.0

--- a/tests/test_tone_shaper.py
+++ b/tests/test_tone_shaper.py
@@ -1,0 +1,7 @@
+from utilities.tone_shaper import ToneShaper
+
+
+def test_choose_preset_drive() -> None:
+    shaper = ToneShaper()
+    preset = shaper.choose_preset(90.0, "high")
+    assert preset == "drive"

--- a/tests/test_user_history.py
+++ b/tests/test_user_history.py
@@ -1,12 +1,14 @@
 import json
+
 from utilities import user_history
 
 
 def test_record_and_load(tmp_path, monkeypatch):
-    hist_file = tmp_path / "hist.json"
+    hist_file = tmp_path / "hist.jsonl"
     monkeypatch.setattr(user_history, "_HISTORY_FILE", hist_file)
     user_history.record_generate({"bpm": 120}, [{"instrument": "bass"}])
-    data = json.loads(hist_file.read_text())
+    lines = hist_file.read_text().splitlines()
+    data = [json.loads(lines[0])]
     assert data[0]["config"]["bpm"] == 120
     loaded = user_history.load_history()
     assert loaded == data

--- a/utilities/articulation_mapper.py
+++ b/utilities/articulation_mapper.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from music21 import note, stream
+
+_DEFAULT_PROFILE: dict[str, int] = {"finger": 28, "slap": 25, "mute": 29}
+
+
+def add_key_switches(part: stream.Part, profile: dict[str, int] | None = None) -> stream.Part:
+    """Insert articulation key switch notes into ``part``.
+
+    The first key switch is inserted two beats before the first note.
+    ``profile`` maps articulation names to MIDI pitches. Unspecified
+    values fall back to ``_DEFAULT_PROFILE``.
+    """
+    mapping = _DEFAULT_PROFILE.copy()
+    if profile:
+        mapping.update(profile)
+
+    # use "finger" articulation as default initial switch
+    ks_pitch = mapping.get("finger", _DEFAULT_PROFILE["finger"])
+    ks = note.Note(ks_pitch, quarterLength=0.0)
+    part.insert(-2.0, ks)  # two beats before start
+    return part
+
+
+__all__ = ["add_key_switches"]

--- a/utilities/config_loader.py
+++ b/utilities/config_loader.py
@@ -11,9 +11,14 @@ YAML 形式の main_cfg を辞書にパースして返す。
 """
 
 from __future__ import annotations
-import yaml, logging
+
+import logging
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Dict, Any, Optional, Mapping
+from typing import Any
+
+import yaml
+
 from utilities import humanizer
 
 # from some_chordmap_loader import load_chordmap  # 既存の関数 (もしあれば)
@@ -47,7 +52,7 @@ def _get_role_dispatch():
 
 
 # ------------------------------------------------------------
-def load_main_cfg(path: str | Path, *, strict: bool = True) -> Dict[str, Any]:
+def load_main_cfg(path: str | Path, *, strict: bool = True) -> dict[str, Any]:
     """
     Load main_cfg.yml and return an expanded dict.
 
@@ -69,7 +74,7 @@ def load_main_cfg(path: str | Path, *, strict: bool = True) -> Dict[str, Any]:
         raise FileNotFoundError(path)
 
     with path.open(encoding="utf-8") as f:
-        cfg: Dict[str, Any] = yaml.safe_load(f) or {}
+        cfg: dict[str, Any] = yaml.safe_load(f) or {}
 
     # 必須キー検証
     try:
@@ -121,6 +126,11 @@ def load_main_cfg(path: str | Path, *, strict: bool = True) -> Dict[str, Any]:
     _validate_roles(cfg)
 
     humanizer.load_profiles(cfg.get("humanize_profiles", {}))  # ★追加
+    gset_flags = cfg.get("global_settings", {})
+    humanizer.set_cc_flags(
+        bool(gset_flags.get("use_expr_cc11", False)),
+        bool(gset_flags.get("use_aftertouch", False)),
+    )
 
     return cfg
 
@@ -152,7 +162,7 @@ def _validate(cfg: Mapping[str, Any]) -> None:
         raise ValueError(f"[paths] missing key(s): {sorted(pp)}")
 
 
-def _validate_roles(cfg: Dict[str, Any]) -> None:
+def _validate_roles(cfg: dict[str, Any]) -> None:
     """part_defaults の role 値が role_dispatch に存在するかチェック"""
     role_dispatch = cfg.get("role_dispatch", {})
     valid_roles = set(role_dispatch.keys())
@@ -179,7 +189,7 @@ def _lazy_import(module_path: str, cls_name: str):
     return _factory
 
 
-def _merge_section_override(cfg: Dict[str, Any], section_name: str) -> Dict[str, Any]:
+def _merge_section_override(cfg: dict[str, Any], section_name: str) -> dict[str, Any]:
     """
     元の cfg から section_overrides を取り出し、対象セクションへの
     上書きをマージした辞書を返す（deep merge は最小限）。
@@ -210,7 +220,7 @@ def load_chordmap_yaml(path: Path | str) -> Any:  # ChordMapの型に合わせ�
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"Chordmap file not found: {path}")
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         # ここでは単純にyaml.safe_loadを呼ぶ例。
         # 実際にはChordMapオブジェクトを返すなど、適切な処理が必要。
         data = yaml.safe_load(f)

--- a/utilities/emotion_arranger.py
+++ b/utilities/emotion_arranger.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from music21 import instrument
+
+from generator.bass_generator import BassGenerator
+from utilities.config_loader import load_chordmap_yaml
+from utilities.emotion_profile_loader import load_emotion_profile
+from utilities.rhythm_library_loader import load_rhythm_library
+
+
+def generate_bass_arrangement(
+    chordmap_path: str | Path,
+    rhythm_library_path: str | Path,
+    emotion_profile_path: str | Path,
+) -> dict[str, dict[str, Any]]:
+    """Return bass pattern choices per section based on emotion.
+
+    Parameters
+    ----------
+    chordmap_path : str | Path
+        YAML chord map describing sections and emotions.
+    rhythm_library_path : str | Path
+        Path to rhythm library YAML.
+    emotion_profile_path : str | Path
+        Path to emotion profile YAML for BassGenerator.
+
+    Returns
+    -------
+    Dict[str, Dict[str, Any]]
+        Mapping of section name to arrangement data. Currently only contains
+        ``"bass_pattern_key"``.
+    """
+    chordmap = load_chordmap_yaml(Path(chordmap_path))
+    rhythm_lib = load_rhythm_library(str(rhythm_library_path))
+    _ = load_emotion_profile(emotion_profile_path)
+
+    global_settings = chordmap.get("global_settings", {})
+    tempo = int(global_settings.get("tempo", 120))
+    ts = str(global_settings.get("time_signature", "4/4"))
+    key_tonic = global_settings.get("key_tonic", "C")
+    key_mode = global_settings.get("key_mode", "major")
+
+    gen = BassGenerator(
+        part_name="bass",
+        default_instrument=instrument.AcousticBass(),
+        global_settings={},
+        global_tempo=tempo,
+        global_time_signature=ts,
+        global_key_signature_tonic=key_tonic,
+        global_key_signature_mode=key_mode,
+        main_cfg={"global_settings": {}},
+        emotion_profile_path=str(emotion_profile_path),
+        part_parameters=rhythm_lib.bass_patterns or {},
+    )
+
+    arrangement: dict[str, dict[str, Any]] = {}
+    for name, section in chordmap.get("sections", {}).items():
+        intent = section.get("musical_intent", {})
+        pattern_key = gen._choose_bass_pattern_key(intent)
+        arrangement[name] = {"bass_pattern_key": pattern_key}
+
+    return arrangement

--- a/utilities/interactive_engine.py
+++ b/utilities/interactive_engine.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from typing import Any
-import warnings
 
 try:
     import mido
@@ -18,32 +18,52 @@ from .ai_sampler import TransformerBassGenerator
 class InteractiveEngine:
     """Trigger bass generation on incoming MIDI events."""
 
-    def __init__(self, model_name: str = "gpt2-music", bpm: float = 120.0) -> None:
+    def __init__(
+        self,
+        *,
+        backend: str = "transformer",
+        model_name: str = "gpt2-medium",
+        bpm: float = 120.0,
+        buffer_ms: int = 100,
+        lookahead_bars: float = 0.5,
+    ) -> None:
+        if backend != "transformer":
+            raise ValueError("Only transformer backend supported")
         self.generator = TransformerBassGenerator(model_name)
         self.bpm = bpm
+        self.buffer_ms = buffer_ms
+        self.lookahead_bars = lookahead_bars
         self.callbacks: list[Callable[[dict], None]] = []
 
     def add_callback(self, callback: Callable[[dict], None]) -> None:
         self.callbacks.append(callback)
 
-    def _trigger(self, msg: Any) -> None:
+    def _trigger(self, msg: Any) -> list[dict]:
+        """Return generated events for ``msg`` if it is a note on."""
         if msg.type == "note_on" and msg.velocity > 0:
-            events = self.generator.generate([
-                {"pitch": msg.note, "velocity": msg.velocity}
-            ], 1)
+            events = self.generator.generate(
+                [{"pitch": msg.note, "velocity": msg.velocity}],
+                max(1, int(self.lookahead_bars)),
+            )
             for cb in self.callbacks:
                 for ev in events:
                     cb(ev)
+            return events
+        return []
 
-    def run(self) -> None:
+    async def start(self, midi_in: str, midi_out: str) -> None:
+        """Begin processing ``midi_in`` and sending to ``midi_out``."""
         if mido is None:
             raise RuntimeError(f"mido unavailable: {_MIDO_ERROR}")
-        names = mido.get_input_names()
-        if not names:
-            warnings.warn("No MIDI input ports available", RuntimeWarning)
-            return
-        with mido.open_input(names[0]) as port:
-            for msg in port:
-                self._trigger(msg)
+        with mido.open_input(midi_in) as inp, mido.open_output(midi_out) as out:
+            for msg in inp:
+                events = await asyncio.to_thread(self._trigger, msg)
+                for ev in events:
+                    pitch = int(ev.get("pitch", 36))
+                    vel = int(ev.get("velocity", 100))
+                    out.send(mido.Message("note_on", note=pitch, velocity=vel))
+                    dur = float(ev.get("duration", 0.5))
+                    await asyncio.sleep(dur * 60.0 / self.bpm)
+                    out.send(mido.Message("note_off", note=pitch))
 
 __all__ = ["InteractiveEngine"]

--- a/utilities/loudness_normalizer.py
+++ b/utilities/loudness_normalizer.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import librosa
+import numpy as np
+import soundfile as sf
+
+
+def normalize_wav(path_in: str | Path, path_out: str | Path, target_lufs: float = -14.0) -> None:
+    """Normalize WAV loudness to ``target_lufs`` (approximate)."""
+    y, sr = librosa.load(path_in, sr=None)
+    rms = np.sqrt(np.mean(y ** 2)) or 1e-9
+    current_lufs = 20 * np.log10(rms)
+    gain = 10 ** ((target_lufs - current_lufs) / 20)
+    y_norm = y * gain
+    sf.write(path_out, y_norm, sr)
+
+__all__ = ["normalize_wav"]

--- a/utilities/tone_shaper.py
+++ b/utilities/tone_shaper.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+
+class ToneShaper:
+    """Select amp/cabinet presets and emit CC events."""
+
+    def __init__(self, presets: dict[str, int] | None = None) -> None:
+        self.presets = {"clean": 0, "drive": 32, "svt": 64, "fuzz": 96}
+        if presets:
+            self.presets.update(presets)
+
+    def choose_preset(self, avg_velocity: float, intensity: str) -> str:
+        """Return preset name for given velocity and intensity."""
+        if intensity in {"high", "very_high"} or avg_velocity >= 85:
+            return "drive"
+        if intensity in {"medium_high", "medium"}:
+            return "svt"
+        if intensity in {"medium_low", "low"} or avg_velocity < 60:
+            return "clean"
+        return "fuzz"
+
+    def to_cc_events(self, preset_name: str, offset: float) -> list[dict]:
+        value = self.presets.get(preset_name, self.presets["clean"])
+        return [{"time": float(offset), "number": 31, "value": value}]
+
+__all__ = ["ToneShaper"]

--- a/utilities/user_history.py
+++ b/utilities/user_history.py
@@ -3,23 +3,31 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-_HISTORY_FILE = Path.home() / ".modcompose_history.json"
+_HISTORY_FILE = Path.home() / ".otokotoba" / "history.jsonl"
 
 
 def record_generate(config: dict, events: list[dict]) -> None:
-    history = load_history()
-    history.append({"config": config, "events": events})
-    with _HISTORY_FILE.open("w", encoding="utf-8") as fh:
-        json.dump(history, fh)
+    """Append a generation entry to the history file."""
+    _HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with _HISTORY_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"config": config, "events": events}) + "\n")
 
 
-def load_history() -> list[dict]:
-    if _HISTORY_FILE.exists():
+def load_history(max_items: int = 1000) -> list[dict]:
+    """Return up to ``max_items`` history entries."""
+    if not _HISTORY_FILE.exists():
+        return []
+    try:
+        with _HISTORY_FILE.open("r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except Exception:
+        return []
+    data: list[dict] = []
+    for line in lines[-max_items:]:
         try:
-            with _HISTORY_FILE.open("r", encoding="utf-8") as fh:
-                return json.load(fh)
-        except Exception:
-            return []
-    return []
+            data.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return data
 
 __all__ = ["record_generate", "load_history"]


### PR DESCRIPTION
## Summary
- handle CC11 / aftertouch mapping via new humanizer flags
- implement ToneShaper and loudness normalization utilities
- expose loudness normalization option in CLI render command
- document tone features and new options

## Testing
- `ruff check utilities/tone_shaper.py utilities/loudness_normalizer.py utilities/humanizer.py utilities/config_loader.py modular_composer/cli.py tests/test_tone_shaper.py tests/test_loudness_normalizer.py`
- `mypy utilities/tone_shaper.py utilities/loudness_normalizer.py utilities/humanizer.py utilities/config_loader.py modular_composer/cli.py tests/test_tone_shaper.py tests/test_loudness_normalizer.py`
- `pytest tests/test_ai_sampler.py tests/test_user_history.py tests/test_cli_transformer.py tests/test_interactive_engine.py tests/test_gui_interactive.py tests/test_emotion_arranger.py tests/test_articulation_mapper.py tests/test_tone_shaper.py tests/test_loudness_normalizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68655b48bb5483289ddd86b8a3bc1584