### PR TITLE
Fix mypy unused ignore

### DIFF
--- a/modular_composer/cli.py
+++ b/modular_composer/cli.py
@@ -15,7 +15,7 @@ from typing import cast
 
 import click
 import pretty_midi
-import yaml  # type: ignore
+import yaml
 from music21 import stream as m21stream
 
 import utilities.loop_ingest as loop_ingest


### PR DESCRIPTION
## Summary
- remove unused type ignore in modular CLI

## Testing
- `pytest -q`
- `ruff check .`
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_68657761dd108328871aae37ccd47143