### PR TITLE
Sync humanizer signature and add ToneShaper hook

### DIFF
--- a/modular_composer/cli.py
+++ b/modular_composer/cli.py
@@ -17,6 +17,10 @@ import click
 import pretty_midi
 import yaml
 from music21 import stream as m21stream
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from music21.stream import Part  # type: ignore[attr-defined]
 
 import utilities.loop_ingest as loop_ingest
 from utilities import (
@@ -310,7 +314,7 @@ def live_cmd(
         )
         parsed = converter.parse(str(model))
         part_stream = parsed.parts[0] if hasattr(parsed, "parts") else parsed
-        part = cast(m21stream.Part, part_stream)
+        part = cast("Part", part_stream)
         if buffer_ahead > 0:
             async def _run() -> None:
                 await streamer.play_live(

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import subprocess
 import sys
 import types
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # 1. subprocess.check_call を薄くラップ
@@ -17,7 +19,7 @@ from pathlib import Path
 _orig_check_call = subprocess.check_call  # keep original
 
 
-def _stub_check_call(cmd, *args, **kwargs):  # noqa: D401
+def _stub_check_call(cmd: Sequence[str] | str, *args: Any, **kwargs: Any) -> int:  # noqa: D401
     """Intercept mkdocs and build commands for lightweight stubbing."""
     # cmd may be list / tuple / str
     if isinstance(cmd, list | tuple):


### PR DESCRIPTION
## Summary
- ensure `humanize_velocities` exposes CC parameters
- integrate ToneShaper logic into BassGenerator compose step
- fix ruff/mypy issues in helper scripts

## Testing
- `ruff check .`
- `mypy modular_composer utilities tests --strict`
- `pytest tests/test_loudness_meter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866677cb0c88328a49b1aad959343d0