### PR TITLE
Enhance tone shaping and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
+          pip install -e .[test] -r requirements-test.txt
           pip install music21
       - name: Restore Essentia wheel cache
         if: runner.os == 'Linux'

--- a/.github/workflows/groove.yml
+++ b/.github/workflows/groove.yml
@@ -5,6 +5,7 @@ jobs:
   train:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env: ${{ matrix.env }}
     strategy:
       matrix:
         include:
@@ -12,6 +13,7 @@ jobs:
               PURE_PY: '1'
           - env:
               CYTHON: '1'
+              MCY_USE_CYTHON: '1'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -34,7 +36,7 @@ jobs:
       - name: build cyext
         run: |
           if [ "${{ matrix.env.CYTHON }}" = '1' ]; then
-            MCY_USE_CYTHON=1 python setup.py build_ext --inplace
+            python setup.py build_ext --inplace
           else
             echo "skip C extension build"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -r requirements.txt
+      - run: pip install -e .[test] -r requirements-test.txt
       - run: pip install music21
       - run: bash scripts/ci_groove.sh
       - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -765,10 +765,13 @@ Common CLI options:
 - `--late-humanize` shifts note timing a few milliseconds right before playback.
 - `--rhythm-schema` prepends a rhythm style token when sampling transformer bass.
 - `--normalize-lufs` normalises rendered audio to the given loudness target.
+- `normalize_wav` can also infer targets per section using
+  `{'verse': -16, 'chorus': -12}`.
 - `--buffer-ahead` and `--parallel-bars` control the pre-generation buffer for
   live mode. Increase them if generation is slow.
-- ToneShaper selects amp presets and emits CC31 at the start of each part.
-  Use it automatically at the end of `BassGenerator.compose()`:
+- ToneShaper selects amp presets using both intensity and average note
+  velocity, then emits CC31 at the start of each part. Use it automatically at
+  the end of `BassGenerator.compose()`:
 
   ```python
   from utilities.tone_shaper import ToneShaper

--- a/docs/tone.md
+++ b/docs/tone.md
@@ -37,7 +37,8 @@ humanizer.apply(part, global_settings={"use_expr_cc11": True, "use_aftertouch": 
 
 Measure the average note velocity of a part and feed the value to
 ``ToneShaper.choose_preset`` together with an intensity label.
-The returned preset is converted to a CC#31 event which should be inserted at
+Both values are combined to determine the preset. The returned preset is
+converted to a CC#31 event which should be inserted at
 the start of the part.
 
 ```python
@@ -51,14 +52,15 @@ part.extra_cc = shaper.to_cc_events(preset, offset=0.0)
 A simplified decision flow:
 
 ```
-mean velocity -> intensity bucket -> preset name
+mean velocity + intensity -> preset name
 ```
 
 ## Loudness Normalisation
 
 When rendering audio with ``modcompose render`` pass ``--normalize-lufs`` to
-target a specific loudness level. The helper ``normalize_wav`` rewrites the WAV
-file in place:
+target a specific loudness level. The helper ``normalize_wav`` can infer a
+target from the section name using ``{'verse': -16, 'chorus': -12}`` and
+rewrites the WAV file in place:
 
 ```bash
 modcompose render spec.yml --soundfont sf2 --normalize-lufs -14

--- a/tests/test_cc_field_consistency.py
+++ b/tests/test_cc_field_consistency.py
@@ -9,7 +9,7 @@ def test_extra_cc_keys_consistent() -> None:
     n.volume.velocity = 90
     part.insert(0.0, n)
     settings = {"use_expr_cc11": True, "use_aftertouch": True}
-    _humanize_velocities(part, amount=3, global_settings=settings)
+    _humanize_velocities(part, amount=3, global_settings=settings, expr_curve="cubic-in")
     for ev in getattr(part, "extra_cc", []):
         assert "cc" in ev and "val" in ev
         assert "number" not in ev and "value" not in ev

--- a/tests/test_cy_humanize_equiv.py
+++ b/tests/test_cy_humanize_equiv.py
@@ -38,8 +38,8 @@ def test_humanize_vel_equiv():
     p1 = _make_part()
     p2 = _make_part()
     settings = {"use_expr_cc11": True, "use_aftertouch": True}
-    _humanize_velocities(p1, amount=5, global_settings=settings)
-    cy_humanize(p2, 5, True, True)
+    _humanize_velocities(p1, amount=5, global_settings=settings, expr_curve="cubic-in")
+    cy_humanize(p2, 5, True, True, "cubic-in")
     v1 = [n.volume.velocity for n in p1.notes]
     v2 = [n.volume.velocity for n in p2.notes]
     assert v1 == v2

--- a/tests/test_live_buffer_integration.py
+++ b/tests/test_live_buffer_integration.py
@@ -65,4 +65,4 @@ def test_rt_play_live(monkeypatch):
     on_times = [t for t, msg in midi.events if msg[0] == 0x90]
     assert len(on_times) == 2
     diff = on_times[1] - on_times[0]
-    assert 0.23 <= diff <= 0.27
+    assert 0.24 <= diff <= 0.26

--- a/utilities/loudness_normalizer.py
+++ b/utilities/loudness_normalizer.py
@@ -7,8 +7,22 @@ import numpy as np
 import soundfile as sf
 
 
-def normalize_wav(path_in: str | Path, path_out: str | Path, target_lufs: float = -14.0) -> None:
-    """Normalize WAV loudness to ``target_lufs`` (approximate)."""
+DEFAULT_TARGET_LUFS_MAP = {"verse": -16.0, "chorus": -12.0}
+
+
+def normalize_wav(
+    path_in: str | Path,
+    path_out: str | Path,
+    target_lufs: float | None = None,
+    *,
+    section: str | None = None,
+    target_lufs_map: dict[str, float] | None = None,
+) -> None:
+    """Normalize WAV loudness to ``target_lufs`` or map-based value."""
+    if target_lufs_map is None:
+        target_lufs_map = DEFAULT_TARGET_LUFS_MAP
+    if target_lufs is None:
+        target_lufs = float(target_lufs_map.get(section, -14.0))
     y, sr = librosa.load(path_in, sr=None)
     rms = np.sqrt(np.mean(y ** 2)) or 1e-9
     current_lufs = 20 * np.log10(rms)

--- a/utilities/tone_shaper.py
+++ b/utilities/tone_shaper.py
@@ -17,14 +17,27 @@ class ToneShaper:
         self._knn = None
 
     def choose_preset(self, avg_velocity: float, intensity: str) -> str:
-        """Return preset name for given velocity and intensity."""
-        if intensity in {"high", "very_high"} or avg_velocity >= 85:
+        """Return preset name derived from intensity and average velocity."""
+        score = 0
+        if intensity in {"very_high", "high"}:
+            score += 2
+        elif intensity in {"medium_high", "medium"}:
+            score += 1
+        elif intensity in {"medium_low", "low"}:
+            score -= 1
+        if avg_velocity >= 90:
+            score += 2
+        elif avg_velocity >= 75:
+            score += 1
+        elif avg_velocity < 60:
+            score -= 1
+        if score >= 3:
+            return "fuzz"
+        if score == 2:
             return "drive"
-        if intensity in {"medium_high", "medium"}:
+        if score >= 0:
             return "svt"
-        if intensity in {"medium_low", "low"} or avg_velocity < 60:
-            return "clean"
-        return "fuzz"
+        return "clean"
 
     def to_cc_events(self, preset_name: str, offset: float) -> list[dict]:
         value = self.presets.get(preset_name, self.presets["clean"])


### PR DESCRIPTION
## Summary
- tighten timing tolerance in live buffer test
- install test requirements in CI workflows
- set cython env vars in Groove workflow
- combine intensity with velocity when choosing presets
- allow cubic-in curve for velocity humanization
- extend loudness normalizer with section targets
- document tone and loudness updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: music21)*

------
https://chatgpt.com/codex/tasks/task_e_6866e76c51a48328a25fbd5f5f4f9f80