### PR TITLE
Finalize FX amp presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,16 @@ Metrics include swing accuracy, note density and velocity variance.
 ``BLEC`` (Binned Log-likelihood Error per Class) is computed as
 ``mean( KL(p_true || p_pred) / log(N) )`` where ``N`` is the number of bins.
 
+## Effects & Rendering
+
+Use ``modcompose fx render`` to convolve a MIDI file with an impulse response:
+
+```bash
+modcompose fx render song.mid --preset CRUNCH --ir 4x12
+```
+
+Impulse responses distributed with this project are licensed under CC-BY 4.0.
+
 ## ABX Test
 
 Launch a simple browser-based ABX comparison:

--- a/docs/amp_guide.md
+++ b/docs/amp_guide.md
@@ -1,0 +1,27 @@
+# Amp & IR Guide
+
+The tone system reads presets from `data/amp_presets.yml`.
+
+```yaml
+presets:
+  clean: 20
+  crunch: 50
+ir:
+  clean: "irs/blackface-clean.wav"
+levels:
+  clean: {reverb: 40, chorus: 20}
+rules:
+  - if: "intensity=='high'"
+    preset: crunch
+```
+
+## CC Mapping
+
+| Parameter | CC# |
+|-----------|----|
+| Amp type  | 31 |
+| Reverb    | 91 |
+| Chorus    | 93 |
+| Delay     | 94 |
+
+Impulse responses are looked up relative to the project root under `irs/`.

--- a/modular_composer/cli.py
+++ b/modular_composer/cli.py
@@ -230,6 +230,40 @@ def preset_import(file: Path, name: str | None) -> None:
     preset_manager.save_preset(name or file.stem, cfg)
 
 
+@cli.group()
+def fx() -> None:
+    """Effects and rendering commands."""
+
+
+@fx.command("render")
+@click.argument("midi", type=Path)
+@click.option("--preset", type=str, default=None)
+@click.option("--ir", "ir_name", type=str, default=None)
+@click.option("-o", "--out", type=Path, default=Path("out.wav"))
+@click.option("--soundfont", type=Path, default=None)
+def fx_render(
+    midi: Path,
+    preset: str | None,
+    ir_name: str | None,
+    out: Path,
+    soundfont: Path | None,
+) -> None:
+    """Render ``midi`` to ``out`` applying optional IR convolution."""
+    from utilities import synth
+    synth.export_audio(midi, out, soundfont=soundfont, ir_file=ir_name)
+    click.echo(str(out))
+
+
+@fx.command("list-presets")
+def fx_list_presets() -> None:
+    """List available amp presets."""
+    from utilities.tone_shaper import ToneShaper
+
+    ts = ToneShaper.from_yaml(Path("data/amp_presets.yml"))
+    for name in ts.preset_map:
+        click.echo(name)
+
+
 @cli.command("live")
 @click.argument("model", type=Path)
 @click.option(

--- a/tests/test_cli_fx.py
+++ b/tests/test_cli_fx.py
@@ -1,0 +1,14 @@
+import subprocess
+from pathlib import Path
+
+
+def test_cli_fx_render(tmp_path: Path) -> None:
+    midi = tmp_path / "demo.mid"
+    midi.write_bytes(
+        b"MThd\x00\x00\x00\x06\x00\x01\x00\x01\x00\x60MTrk\x00\x00\x00\x04\x00\xFF\x2F\x00"
+    )
+    out = tmp_path / "out.wav"
+    subprocess.check_call(
+        ["modcompose", "fx", "render", str(midi), "-o", str(out), "--preset", "clean"]
+    )
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add ToneShaper validation and warnings
- implement fx render/list-presets commands
- document amp/IR usage
- add guitar_fx_demo.mid example
- expand amp preset tests and new CLI test
- update README with effects section
- remove binary demo MIDI and generate file in CLI test

## Testing
- `ruff check .`
- `mypy modular_composer`
- `pytest -m "packaging or docs or fx" -q`


------
https://chatgpt.com/codex/tasks/task_e_6867d1e36a888328a8a6823a57f8d566