### PR TITLE
Phase 5-2 effect chain updates

### DIFF
--- a/generator/base_part_generator.py
+++ b/generator/base_part_generator.py
@@ -69,9 +69,9 @@ class BasePartGenerator(ABC):
             return
         avg_vel = statistics.mean(n.volume.velocity or 64 for n in notes)
         shaper = ToneShaper()
-        preset = shaper.choose_preset(avg_vel, intensity)
+        shaper.choose_preset(avg_vel, intensity)
         existing = [c for c in getattr(part, "extra_cc", []) if c.get("cc") != 31]
-        part.extra_cc = existing + shaper.to_cc_events(preset, 0.0)
+        part.extra_cc = existing + shaper.to_cc_events(0.0, as_dict=True)
 
     def compose(
         self,

--- a/generator/guitar_generator.py
+++ b/generator/guitar_generator.py
@@ -542,6 +542,10 @@ class GuitarGenerator(BasePartGenerator):
             if fx_params:
                 self._apply_fx_cc(p, fx_params, section.get("musical_intent", {}))
 
+            eff_env = section.get("effect_envelope")
+            if eff_env:
+                self._apply_effect_envelope(p, eff_env)
+
             # ── Amp / Cab プリセット & IR ファイル登録 ───────────
             notes   = list(p.flatten().notes)
             avg_vel = statistics.mean(n.volume.velocity or 64 for n in notes) if notes else 64.0
@@ -2191,14 +2195,89 @@ class GuitarGenerator(BasePartGenerator):
             events.append({"time": 0.0, "cc": 93, "val": int(fx_params["chorus_send"])})
         if "delay_send" in fx_params:
             events.append({"time": 0.0, "cc": 94, "val": int(fx_params["delay_send"])})
+
+        pick_pos = fx_params.get("pick_position")
+        if pick_pos is not None:
+            try:
+                pick = float(pick_pos)
+                notes = sorted(part.flatten().notes, key=lambda n: n.offset)
+                for n in notes:
+                    vel = n.volume.velocity or 64
+                    val = int(max(0, min(127, round(pick * 127 * vel / 127))))
+                    events.append({"time": float(n.offset), "cc": 74, "val": val})
+            except Exception:
+                pass
+
+        curve = fx_params.get("brightness_curve")
+        if curve:
+            try:
+                pts = sorted((float(b), float(v)) for b, v in curve)
+            except Exception:
+                pts = []
+            if len(pts) >= 2:
+                for i in range(len(pts) - 1):
+                    b0, v0 = pts[i]
+                    b1, v1 = pts[i + 1]
+                    if b1 <= b0:
+                        continue
+                    steps = max(2, int((b1 - b0) * 4))
+                    for s in range(steps + 1):
+                        frac = s / steps
+                        val = int(round(v0 + (v1 - v0) * frac))
+                        t = b0 + (b1 - b0) * frac
+                        events.append({"time": t, "cc": 74, "val": max(0, min(127, val))})
         part.extra_cc = events
 
-    def export_audio(self, midi_path: str | Path, out_wav: str | Path, **kwargs):
+    def _apply_effect_envelope(self, part: stream.Part, envelope_map: dict) -> None:
+        events = getattr(part, "extra_cc", [])
+        bpm = float(self.global_tempo or 120.0)
+        step_ql = bpm / 3000.0  # 20 ms in quarterLength
+        for off, spec in envelope_map.items():
+            try:
+                start = float(off)
+            except Exception:
+                continue
+            dur = float(spec.get("duration_ql", 1.0))
+            cc_num = int(spec.get("cc", 91))
+            start_val = int(spec.get("start_val", spec.get("start", 0)))
+            end_val = int(spec.get("end_val", spec.get("end", 127)))
+            shape = str(spec.get("shape", "lin"))
+            steps = max(1, int(dur / step_ql))
+            for i in range(steps + 1):
+                frac = i / steps
+                if shape == "exp":
+                    frac = frac * frac
+                val = int(round(start_val + (end_val - start_val) * frac))
+                t = start + dur * frac
+                events.append({"time": t, "cc": cc_num, "val": max(0, min(127, val))})
+        part.extra_cc = events
+
+    def export_audio(
+        self,
+        midi_path: str | Path,
+        out_wav: str | Path,
+        *,
+        realtime: bool = False,
+        write_mix_json: bool = False,
+        streamer=None,
+        **kwargs,
+    ):
         """Render and convolve using the last composed part's IR."""
         from utilities.synth import export_audio as synth_export_audio
+        from utilities import mix_profile
+        from utilities import rt_midi_streamer
 
         part = getattr(self, "_last_part", None)
-        return synth_export_audio(midi_path, out_wav, part=part, **kwargs)
+        if realtime and part is not None:
+            if streamer is None:
+                streamer = rt_midi_streamer.RtMidiStreamer("dummy")  # pragma: no cover - default
+            rt_midi_streamer.stream_cc_events(part, streamer)
+            return None
+
+        wav = synth_export_audio(midi_path, out_wav, part=part, **kwargs)
+        if write_mix_json and part is not None:
+            mix_profile.export_mix_json(part, Path(out_wav).with_suffix(".json"))
+        return wav
 
 
 

--- a/tests/test_effect_cc.py
+++ b/tests/test_effect_cc.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 import pytest
 from music21 import instrument
 from generator.guitar_generator import GuitarGenerator
@@ -39,3 +42,90 @@ def test_fx_cc_injection(_gen):
     assert (91, 80) in ccs
     assert (93, 60) in ccs
     assert any(e[0] == 31 for e in ccs)
+
+
+def test_effect_envelope_increasing(_gen):
+    gen = _gen()
+    gen.part_parameters["pat"] = {
+        "pattern": [{"offset": 0.0, "duration": 4.0}],
+        "reference_duration_ql": 4.0,
+    }
+    sec = {
+        "section_name": "A",
+        "q_length": 4.0,
+        "humanized_duration_beats": 4.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {"g": {"guitar_rhythm_key": "pat"}},
+        "effect_envelope": {
+            0.0: {"cc": 91, "start_val": 0, "end_val": 100, "duration_ql": 4.0, "shape": "lin"}
+        },
+    }
+    part = gen.compose(section_data=sec)
+    events = [e for e in part.extra_cc if e.get("cc") == 91]
+    events.sort(key=lambda x: x["time"])
+    vals = [e["val"] for e in events if e["time"] > 0.0]
+    assert vals == sorted(vals) and vals[0] < vals[-1]
+
+
+def test_export_audio_realtime(monkeypatch, tmp_path, _gen):
+    gen = _gen()
+    p = gen.compose(section_data={
+        "section_name": "A",
+        "q_length": 1.0,
+        "humanized_duration_beats": 1.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {"g": {"guitar_rhythm_key": "pat"}},
+        "fx_params": {"reverb_send": 80},
+    })
+    midi = tmp_path / "in.mid"
+    wav = tmp_path / "out.wav"
+    midi.write_text("dummy")
+
+    calls = []
+
+    class Dummy:
+        tempo = type("T", (), {"events": [{"beat": 0.0, "bpm": 120.0}]})()
+
+        def send_cc(self, cc, value, time):
+            calls.append((cc, value))
+
+    gen.export_audio(midi, wav, realtime=True, streamer=Dummy())
+    assert calls
+
+
+def test_mix_metadata_json(tmp_path, monkeypatch, _gen):
+    gen = _gen()
+    gen.tone_shaper.ir_map["clean"] = "ir.wav"
+    gen.part_parameters["pat"] = {
+        "pattern": [{"offset": 0.0, "duration": 1.0}],
+        "reference_duration_ql": 1.0,
+    }
+    sec = {
+        "section_name": "A",
+        "q_length": 1.0,
+        "humanized_duration_beats": 1.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {"g": {"guitar_rhythm_key": "pat"}},
+        "fx_params": {"reverb_send": 80},
+    }
+    part = gen.compose(section_data=sec)
+    midi = tmp_path / "i.mid"
+    wav = tmp_path / "o.wav"
+    midi.write_text("m")
+
+    def fake_export(mp, ow, part=None, **kw):
+        Path(ow).touch()
+        return Path(ow)
+
+    import utilities.synth as synth
+
+    monkeypatch.setattr(synth, "export_audio", fake_export)
+
+    gen.export_audio(midi, wav, write_mix_json=True)
+    meta = json.loads(wav.with_suffix(".json").read_text())
+    key = part.id or "part"
+    assert "ir_file" in meta[key]
+    assert meta[key]["extra_cc"]

--- a/tests/test_guitar_phase4.py
+++ b/tests/test_guitar_phase4.py
@@ -76,6 +76,29 @@ def test_pick_position_cc74(_basic_gen):
     assert val2 > val1
 
 
+def test_fx_pick_position_cc74(_basic_gen):
+    gen = _basic_gen()
+    gen.part_parameters["qpat"] = {
+        "pattern": [{"offset": 0.0, "duration": 1.0}],
+        "reference_duration_ql": 1.0,
+    }
+    base = {
+        "section_name": "A",
+        "q_length": 1.0,
+        "humanized_duration_beats": 1.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {"g": {"guitar_rhythm_key": "qpat"}},
+    }
+    sec1 = base | {"fx_params": {"pick_position": 0.2}}
+    sec2 = base | {"fx_params": {"pick_position": 0.8}}
+    p1 = gen.compose(section_data=sec1)
+    p2 = gen.compose(section_data=sec2)
+    val1 = [c["val"] for c in p1.extra_cc if c.get("cc") == 74][0]
+    val2 = [c["val"] for c in p2.extra_cc if c.get("cc") == 74][0]
+    assert val2 > val1
+
+
 def test_style_hint_soft(_basic_gen):
     gen = _basic_gen()
     gen.part_parameters["qpat"] = {

--- a/utilities/mix_profile.py
+++ b/utilities/mix_profile.py
@@ -26,4 +26,32 @@ def get_mix_chain(name: str, default: dict | None = None) -> dict | None:
     return _MIX_MAP.get(name, default)
 
 
+def export_mix_json(parts, path: str) -> None:
+    """Export basic mixing metadata for ``parts`` to ``path``."""
+    data = {}
+
+    def _add(name: str, part) -> None:
+        entry = {
+            "extra_cc": getattr(part, "extra_cc", []),
+        }
+        meta = getattr(part, "metadata", None)
+        if meta is not None:
+            ir_file = getattr(meta, "ir_file", None)
+            if ir_file:
+                entry["ir_file"] = ir_file
+        shaper = getattr(part, "tone_shaper", None)
+        if shaper is not None and hasattr(shaper, "_selected"):
+            entry["preset"] = shaper._selected
+        data[name] = entry
+
+    if isinstance(parts, dict):
+        for k, v in parts.items():
+            _add(k, v)
+    else:
+        _add(getattr(parts, "id", "part"), parts)
+
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+
 load_mix_profiles()


### PR DESCRIPTION
## Summary
- implement realtime CC streaming helper
- add effect envelope DSL support
- export mix metadata json
- support brightness and pick-position CC74 automation
- extend tests for new envelope and realtime modes

## Testing
- `pytest tests/test_effect_cc.py::test_fx_cc_injection tests/test_effect_cc.py::test_effect_envelope_increasing tests/test_effect_cc.py::test_export_audio_realtime tests/test_effect_cc.py::test_mix_metadata_json tests/test_guitar_phase4.py::test_fx_pick_position_cc74 -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ce5dbf588328b209ee12170b1ab5