### PR TITLE
Migrate ToneShaper fallback

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,4 +4,6 @@
 - `ToneShaper.choose_preset` now requires keyword arguments: `amp_hint`, `intensity`, `avg_velocity`.
 - `ToneShaper.to_cc_events` expects `amp_name` and returns a set of tuples.
 - `merge_cc_events` accepts any `Iterable` but pass `set(base)` when combining lists.
+- `ToneShaper.choose_preset` falls back to `<amp_hint>_default` when `amp_hint`
+  isn't found.
 

--- a/docs/live_tips.md
+++ b/docs/live_tips.md
@@ -29,7 +29,7 @@ modcompose live model.pkl --late-humanize 6 --kick-leak-jitter 3
   shaper = ToneShaper()
   preset = shaper.choose_preset(intensity="medium", avg_velocity=avg_vel)
   part.extra_cc.extend(
-      shaper.to_cc_events(amp_name=preset, intensity="medium", offset_ql=0.0, as_dict=True)
+      shaper.to_cc_events(amp_name=preset, intensity="medium", as_dict=True)
   )
   ```
 

--- a/tests/test_tone_shaper.py
+++ b/tests/test_tone_shaper.py
@@ -43,7 +43,7 @@ def test_choose_preset_fallback() -> None:
     # amp_hint が unknown → default へフォールバック
     assert (
         shaper.choose_preset(amp_hint="unknown", intensity="low", avg_velocity=50.0)
-        == "clean"
+        == "unknown_default"
     )
 
 

--- a/utilities/tone_shaper.py
+++ b/utilities/tone_shaper.py
@@ -142,7 +142,16 @@ class ToneShaper:
         avg_velocity = 64.0 if avg_velocity is None else float(avg_velocity)
 
         # 1) explicit
-        chosen: str | None = amp_hint if amp_hint in self.preset_map else None
+        chosen: str | None = None
+        if amp_hint is not None:
+            if amp_hint in self.preset_map:
+                chosen = amp_hint
+            else:
+                chosen = f"{amp_hint}_default"
+                if chosen not in self.preset_map:
+                    self.preset_map[chosen] = self.preset_map.get(
+                        self.default_preset, {"amp": 80}
+                    )
 
         lvl_raw = (intensity or "medium").lower()
         lvl = lvl_raw if lvl_raw in {"low", "medium", "high"} else ""


### PR DESCRIPTION
## Summary
- tweak ToneShaper.choose_preset fallback
- adjust docs and examples for new API
- update ToneShaper fallback test

## Testing
- `pytest tests/test_tone_shaper.py tests/test_amp_presets.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a212a23fc83289cc395ab36ad884d