### PR TITLE
Fix strings divisi and duration logic

### DIFF
--- a/docs/api/strings_generator.md
+++ b/docs/api/strings_generator.md
@@ -19,4 +19,5 @@ above.
   voicing density.
 - `voice_allocation` – optional mapping of chord tone index per section; use
   ``-1`` to silence a section.
-- `divisi` – `bool` or mapping enabling octave or third splits for Violin I/II.
+- `divisi` – `bool` or mapping enabling octave or third splits for Violin I/II. Use `"third"` to add a diatonic third above; if the added third exceeds the instrument range it will drop an octave or be omitted.
+- `avoid_low_open_strings` – when ``True`` transposes viola/violin notes on open C/G strings up an octave.


### PR DESCRIPTION
## Summary
- handle measure duration initialization in `StringsGenerator`
- adjust duration splitting and velocity scaling logic
- support `divisi="third"` for diatonic third doubling with range checks
- merge identical bars and clamp low open strings
- add expression CC crescendo
- add tests for new features
- document range limits for `divisi="third"` and open-string avoidance

## Testing
- `pytest tests/test_strings_phase0.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869f53c4854832882e4cae2d1a0b675