### PR TITLE
Add fluidsynth checks for audio tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,14 @@ jobs:
           path: ~/.cache/pip/wheels/**/essentia*.whl
           key: ${{ runner.os }}-essentia-2_1
       - name: Cache SoundFont
+        if: matrix.variant == 'PIANO_ML'
         id: cache-sf2
         uses: actions/cache@v3
         with:
           path: sf2/TimGM6mb.sf2
           key: ${{ runner.os }}-timgm6mb-sf2
       - name: Install SoundFont
-        if: steps.cache-sf2.outputs.cache-hit != 'true'
+        if: matrix.variant == 'PIANO_ML' && steps.cache-sf2.outputs.cache-hit != 'true'
         run: |
           for i in 1 2 3; do
             sudo apt-get update && sudo apt-get install -y fluidsynth timgm6mb-soundfont && break || sleep 5
@@ -72,6 +73,7 @@ jobs:
           mkdir -p sf2
           cp /usr/share/sounds/sf2/TimGM6mb.sf2 sf2/
       - name: Verify SF2 Size
+        if: matrix.variant == 'PIANO_ML'
         run: ls -lh sf2/TimGM6mb.sf2
       - name: Ruff
         run: ruff check . --output-format=github
@@ -91,6 +93,7 @@ jobs:
         env:
           UPDATE_GOLDENS: ${{ github.event.inputs.update_goldens || '0' }}
       - name: Audio Regression Tests
+        if: matrix.variant == 'PIANO_ML'
         run: |
           rm -rf tmp && mkdir tmp
           python - << 'EOF'
@@ -111,12 +114,13 @@ jobs:
           EOF
         timeout-minutes: 10
       - name: Audio Spectrum Regression
+        if: matrix.variant == 'PIANO_ML'
         run: pytest tests/test_audio_spectrum.py
         timeout-minutes: 5
         env:
           SF2_PATH: sf2/TimGM6mb.sf2
       - name: Upload WAVs on failure
-        if: failure()
+        if: matrix.variant == 'PIANO_ML' && failure()
         uses: actions/upload-artifact@v4
         with:
           name: wav-previews

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ markers =
     no_midi_port: skip tests when no MIDI input is available
     packaging: packaging checks
     docs: documentation build
+    audio: tests requiring fluidsynth
     fx: audio effects tests
     velocity: velocity expression tests
     eval: evaluation tests

--- a/tests/test_export_audio.py
+++ b/tests/test_export_audio.py
@@ -1,9 +1,13 @@
-import types
 from pathlib import Path
 
 import pytest
 
+from utilities.audio_env import has_fluidsynth
+
 sf = pytest.importorskip("soundfile")
+
+if not has_fluidsynth():
+    pytest.skip("fluidsynth missing", allow_module_level=True)
 
 from generator.guitar_generator import GuitarGenerator
 
@@ -61,8 +65,8 @@ def test_export_audio_ir(tmp_path, monkeypatch):
         Path(ow).write_bytes(b"RIFF1111")
         calls["conv"] = True
 
-    import utilities.synth as synth
     import utilities.convolver as conv
+    import utilities.synth as synth
 
     monkeypatch.setattr(synth, "export_audio", fake_export)
     monkeypatch.setattr(conv, "render_with_ir", fake_conv)
@@ -109,8 +113,8 @@ def test_export_audio_missing_ir(tmp_path, monkeypatch):
         nonlocal called
         called = True
 
-    import utilities.synth as synth
     import utilities.convolver as conv
+    import utilities.synth as synth
 
     monkeypatch.setattr(synth, "export_audio", fake_export)
     monkeypatch.setattr(conv, "render_with_ir", fake_conv)

--- a/tests/test_fx_pipeline.py
+++ b/tests/test_fx_pipeline.py
@@ -1,8 +1,12 @@
 import numpy as np
-import soundfile as sf
 import pytest
+import soundfile as sf
 
-from generator.guitar_generator import GuitarGenerator
+from utilities.audio_env import has_fluidsynth
+
+if not has_fluidsynth():
+    pytest.skip("fluidsynth missing", allow_module_level=True)
+
 from utilities.tone_shaper import ToneShaper
 
 

--- a/tests/test_ir_render.py
+++ b/tests/test_ir_render.py
@@ -1,15 +1,19 @@
-import numpy as np
-import pytest
-pytest.importorskip("soundfile")
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from utilities.audio_env import has_fluidsynth
 
 sf = pytest.importorskip("soundfile")
 pyln = pytest.importorskip("pyloudnorm")
 
-from utilities.convolver import render_with_ir
-from utilities.convolver import convolve_ir
+if not has_fluidsynth():
+    pytest.skip("fluidsynth missing", allow_module_level=True)
+
+from utilities.convolver import convolve_ir, render_with_ir
 
 
 def _sine(sr, dur=1.0):

--- a/utilities/audio_env.py
+++ b/utilities/audio_env.py
@@ -1,0 +1,6 @@
+import shutil
+
+
+def has_fluidsynth() -> bool:
+    """Return True if fluidsynth is available on PATH."""
+    return shutil.which("fluidsynth") is not None


### PR DESCRIPTION
## Summary
- add utilities/audio_env helper to check for `fluidsynth`
- skip audio-related tests unless fluidsynth is present
- document `audio` marker in pytest.ini
- only install fluidsynth and run audio regression tests for the `PIANO_ML` CI variant

## Testing
- `ruff check utilities/audio_env.py tests/test_export_audio.py tests/test_fx_pipeline.py tests/test_ir_render.py`
- `pytest tests/test_ir_render.py::test_convolve_length -q` *(fails: Missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_686a38963b3c83288d8b799f72f901c8