### PR TITLE
Add flexible articulation parsing

### DIFF
--- a/docs/strings_generator.md
+++ b/docs/strings_generator.md
@@ -5,6 +5,18 @@ Each rhythm event may specify an `articulations` list. Supported names are:
 `sustain`, `staccato`, `accent`, `tenuto`, `legato`, `tremolo`, `pizz`, and
 `arco`.
 
+The value may be a list or a single string. When using a string,
+multiple names can be joined with `+` or spaces:
+
+```yaml
+events:
+  - duration: 1.0
+    articulations: "staccato+accent"
+```
+
+The special name `sustain` clears any default articulations without adding
+new markings.
+
 Example section data:
 
 ```yaml


### PR DESCRIPTION
## Summary
- handle articulation strings split by `+` and spaces
- skip unknown or `sustain` articulations safely
- document articulation string syntax
- add tests for sustain, multi-articulations, and unknown names

## Testing
- `pytest tests/test_strings_phase1.py tests/test_strings_phase0.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6162edb48328bf3f7e1a366e3e6c