### PR TITLE
Fix piano generator offsets

### DIFF
--- a/generator/piano_template_generator.py
+++ b/generator/piano_template_generator.py
@@ -135,7 +135,13 @@ class PianoTemplateGenerator(BasePartGenerator):
         intensity = section.get("musical_intent", {}).get("intensity", "medium")
         notes = list(part.recurse().notes)
         scaled = self._density_engine.scale_density(notes, str(intensity))
-        for n in list(part.recurse().notes):
-            part.remove(n)
+        note_offsets = []
         for n in scaled:
-            part.insert(float(n.offset), copy.deepcopy(n))
+            cp = copy.deepcopy(n)
+            if hasattr(cp, "activeSite"):
+                cp.activeSite = None
+            note_offsets.append((float(n.offset), cp))
+        for n in notes:
+            part.remove(n)
+        for off, n in note_offsets:
+            part.insert(off, n)

--- a/generator/voicing_density.py
+++ b/generator/voicing_density.py
@@ -47,9 +47,8 @@ class VoicingDensityEngine:
                 new_notes.append(n)
                 try:
                     anticip = copy.deepcopy(n)
-                    anticip.offset = float(n.offset) - 0.5
-                    if anticip.offset >= 0:
-                        new_notes.append(anticip)
+                    anticip.offset = max(0.0, float(n.offset) - 0.5)
+                    new_notes.append(anticip)
                 except Exception:
                     continue
             new_notes.sort(key=lambda n: float(n.offset))


### PR DESCRIPTION
## Summary
- fix offset handling when scaling piano notes
- ensure high density expansion always duplicates notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a838549a08328b3923c059163640d