### PR TITLE
Implement StringsGenerator Phase-2 features

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -76,3 +76,14 @@ Python からは ``GuitarGenerator.export_audio`` を使って IR 名を指定�
 ```python
 gen.export_audio(ir_name="mesa412")
 ```
+
+### StringsGenerator Phase 2 Example
+
+```yaml
+part_params:
+  strings:
+    default_velocity_curve: [30, 80, 110]
+    timing_jitter_ms: 20
+    timing_jitter_scale_mode: bpm_relative
+    bow_position: tasto
+```

--- a/docs/strings_generator.md
+++ b/docs/strings_generator.md
@@ -34,3 +34,17 @@ section["events"] = [
 
 When two consecutive events specify `legato`, a single slur is created.  Default
 articulations apply when an event omits the key.
+
+## Phase 2 Options
+
+StringsGenerator now supports velocity curves, timing jitter and bow position metadata.
+
+- `default_velocity_curve`: a list of 3, 7 or 128 values describing a velocity
+  mapping. Three-point curves are interpolated to 128 steps.
+- `timing_jitter_ms`: maximum random offset in milliseconds.
+- `timing_jitter_mode`: either `"uniform"` or `"gauss"`.
+- `timing_jitter_scale_mode`: `"absolute"` (default) or `"bpm_relative"` which
+  scales `timing_jitter_ms` relative to a reference BPM of 120.
+- `balance_scale`: blend ratio for section dynamics. Lower values reduce
+  contrast.
+- `bow_position`: one of `tasto`, `normale` or `ponticello`.

--- a/tests/test_strings_phase2.py
+++ b/tests/test_strings_phase2.py
@@ -1,0 +1,113 @@
+import importlib.util
+import statistics
+import sys
+from pathlib import Path
+
+import pytest
+from music21 import instrument
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = type(sys)("generator")
+pkg.__path__ = [str(ROOT / "generator")]
+sys.modules.setdefault("generator", pkg)
+
+_MOD_PATH = ROOT / "generator" / "strings_generator.py"
+spec = importlib.util.spec_from_file_location("generator.strings_generator", _MOD_PATH)
+strings_module = importlib.util.module_from_spec(spec)
+sys.modules["generator.strings_generator"] = strings_module
+spec.loader.exec_module(strings_module)
+StringsGenerator = strings_module.StringsGenerator
+
+
+def _basic_section():
+    return {
+        "section_name": "A",
+        "q_length": 4.0,
+        "humanized_duration_beats": 4.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {},
+        "musical_intent": {},
+        "shared_tracks": {},
+    }
+
+
+def _gen(**kwargs):
+    return StringsGenerator(
+        global_settings={},
+        default_instrument=instrument.Violin(),
+        part_name="strings",
+        global_tempo=kwargs.pop("global_tempo", 120),
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        **kwargs,
+    )
+
+
+def test_velocity_curve_mapping():
+    curve = [30, 80, 110]
+    gen = _gen(default_velocity_curve=curve)
+    assert gen.default_velocity_curve[0] == 30
+    assert gen.default_velocity_curve[64] == 80
+    assert gen.default_velocity_curve[127] == 109
+    # midpoint checks
+    assert gen.default_velocity_curve[32] == 55
+    assert gen.default_velocity_curve[96] == 95
+
+
+def test_timing_jitter_bpm_scale():
+    sec = _basic_section()
+    sec["events"] = [{"duration": 1.0} for _ in range(8)]
+    gen_lo = _gen(global_tempo=60, timing_jitter_ms=30, timing_jitter_scale_mode="bpm_relative")
+    gen_hi = _gen(global_tempo=180, timing_jitter_ms=30, timing_jitter_scale_mode="bpm_relative")
+    gen_lo.rng.seed(1)
+    gen_hi.rng.seed(1)
+    notes_lo = gen_lo.compose(section_data=sec)["violin_i"].flatten().notes
+    notes_hi = gen_hi.compose(section_data=sec)["violin_i"].flatten().notes
+    diffs_lo = [float(n.offset) - i for i, n in enumerate(notes_lo)]
+    diffs_hi = [float(n.offset) - i for i, n in enumerate(notes_hi)]
+    ratio = statistics.pstdev(diffs_lo) / statistics.pstdev(diffs_hi)
+    assert ratio == pytest.approx(3.0, rel=0.2)
+
+
+def test_bow_position_meta():
+    gen = _gen()
+    sec = _basic_section()
+    sec["bow_position"] = "tasto"
+    parts = gen.compose(section_data=sec)
+    n = list(parts["violin_i"].flatten().notes)[0]
+    meta = getattr(n.style, "bowPosition", getattr(n.style, "other", None))
+    assert meta == strings_module.BowPosition.TASTO.value
+
+
+def test_balance_scale_effect():
+    gen_hi = _gen()
+    gen_lo = _gen(balance_scale=0.5)
+    sec = _basic_section()
+    parts_hi = gen_hi.compose(section_data=sec)
+    parts_lo = gen_lo.compose(section_data=sec)
+    v_hi = parts_hi["violin_i"].flatten().notes[0].volume.velocity
+    v_lo = parts_lo["violin_i"].flatten().notes[0].volume.velocity
+    assert v_lo < v_hi and v_lo >= 20
+
+
+def test_balance_scale_high_clamp():
+    gen_hi = _gen(balance_scale=1.5)
+    sec = _basic_section()
+    parts = gen_hi.compose(section_data=sec)
+    vel = parts["violin_i"].flatten().notes[0].volume.velocity
+    assert 1 <= vel <= 127
+    gen_def = _gen()
+    vel_def = gen_def.compose(section_data=sec)["violin_i"].flatten().notes[0].volume.velocity
+    assert vel > vel_def
+
+
+def test_jitter_bar_boundary():
+    sec = _basic_section()
+    sec["events"] = [{"duration": 1.0} for _ in range(4)]
+    gen = _gen(global_tempo=60, timing_jitter_ms=100)
+    gen.rng.seed(2)
+    parts = gen.compose(section_data=sec)
+    starts = [float(n.offset) for n in parts["violin_i"].flatten().notes]
+    assert all(s < sec["q_length"] for s in starts)


### PR DESCRIPTION
## Summary
- add velocity curve fallback for arbitrary sequences
- clamp velocity metadata consistently across volume fields
- update timing jitter tests and ensure bar boundaries remain valid
- verify balance scale effect with high values

## Testing
- `ruff check .`
- `mypy generator/strings_generator.py --strict`
- `pytest tests/test_strings_phase2.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686a82c1eab0832884b66badffd48d46