### PR TITLE
Fix CI and doc placeholders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Set ML env (pure)
         if: matrix.variant != 'PIANO_ML'
         run: echo "ENABLE_ML_TESTS=false" >> $GITHUB_ENV
-      - name: Set ML env (beta)
-        if: matrix.variant == 'PG_BETA'
-        run: echo "ENABLE_ML_TESTS=false" >> $GITHUB_ENV
       - name: Set ML env (ml)
         if: matrix.variant == 'PIANO_ML'
         run: echo "ENABLE_ML_TESTS=true" >> $GITHUB_ENV
@@ -84,13 +81,12 @@ jobs:
         run: mypy modular_composer utilities tests --strict
       - name: Debug music21
         run: pip list | grep music21
-      - name: Pytest
-        run: |
-          if [ "$ENABLE_ML_TESTS" = "true" ]; then
-            pytest -q
-          else
-            pytest -q -m "not ml"
-          fi
+      - name: Run pytest (no-ml)
+        if: matrix.variant != 'PIANO_ML'
+        run: pytest -q -m "not ml"
+      - name: Run pytest (ml)
+        if: matrix.variant == 'PIANO_ML'
+        run: pytest -q
       - name: MIDI Regression Tests
         run: pytest tests/test_midi_regression.py
         env:

--- a/README.md
+++ b/README.md
@@ -923,7 +923,7 @@ modcompose sample dummy.pkl --backend piano_template \
 ```
 
 The JSON output now includes ``hand`` and ``pedal`` fields.
-![voicing demo placeholder](docs/img/piano_beta_counter.gif)
+<!-- TODO: replace with actual GIF -->
 
 #### Intensity & Density
 
@@ -933,7 +933,7 @@ The JSON output now includes ``hand`` and ``pedal`` fields.
 | medium    | 100 % (default)    |
 | high      | 110 % + anticipation|
 
-Adjust density with ``--intensity``. See the [test gif](docs/img/piano_beta_quick.gif).
+Adjust density with ``--intensity``. <!-- TODO: replace with actual GIF -->
 
 ## PianoGenerator ML
 

--- a/docs/piano_beta.md
+++ b/docs/piano_beta.md
@@ -7,7 +7,7 @@ modcompose sample dummy.pkl --backend piano_template \
   --voicing drop2 --intensity medium --counterline -o demo.mid
 ```
 
-![demo gif](docs/img/piano_beta_quick.gif)
+<!-- TODO: replace with actual GIF -->
 
 #### Intensity & Density
 
@@ -17,4 +17,4 @@ modcompose sample dummy.pkl --backend piano_template \
 | medium    | 100 % (default)    |
 | high      | 110 % + anticipation|
 
-Use ``--intensity`` to control note density. See the [test gif](docs/img/piano_beta_quick.gif).
+Use ``--intensity`` to control note density. <!-- TODO: replace with actual GIF -->


### PR DESCRIPTION
## Summary
- remove duplicate CI env step and split pytest jobs
- add TODO GIF placeholders in docs

## Testing
- `bash setup.sh` *(fails: missing dependencies)*
- `pytest -q` *(fails: Missing packages: music21, pretty_midi, mido)*

------
https://chatgpt.com/codex/tasks/task_e_686ab537c6048328bfb01c0e1ef8cf2b