### PR TITLE
Add configurable CC map and emotion mapping for strings

### DIFF
--- a/data/cc_map.yml
+++ b/data/cc_map.yml
@@ -1,0 +1,5 @@
+expression: 11
+mod: 1
+bow_pressure: 2
+bow_position: 71
+mute_toggle: 20

--- a/data/expression_maps.yml
+++ b/data/expression_maps.yml
@@ -1,0 +1,19 @@
+gentle_legato:
+  articulations: ["legato"]
+  cc:
+    1: 20
+    11: [40, 80]
+  velocity_curve_name: "soft"
+  mute_velocity_factor: 0.85
+marcato_drive:
+  articulations: ["accent", "detaché"]
+  cc:
+    1: 80
+    11: 90
+  velocity_curve_name: "hard"
+  mute_velocity_factor: 0.85
+emotion_map:
+  default:
+    default: gentle_legato
+    high: marcato_drive
+    very_high: marcato_drive

--- a/docs/strings_generator.md
+++ b/docs/strings_generator.md
@@ -77,3 +77,51 @@ pitch. The note spacing is derived from the specified `rate_hz` using the
 formula ``60 / (tempo * rate_hz)``. Vibrato depth and speed can be provided via
 ``vibrato`` dictionaries either per-event or in `part_params`; generated notes
 store the waveform in ``editorial.vibrato_curve``.
+
+## Phase 4 Options
+
+Expression maps bundle articulations, velocity curves and controller presets.
+Maps are loaded from `data/expression_maps.yml` by default and selected per
+section using `part_params.strings.expression_map`.
+
+```yaml
+gentle_legato:
+  articulations: ["legato"]
+  cc:
+    1: 20
+    11: [40, 80]
+  velocity_curve_name: soft
+```
+
+When unspecified the generator falls back to a map based on emotion and
+intensity, defaulting to `gentle_legato`.
+
+Mapped articulations are appended to `default_articulations`. ``velocity_curve_name``
+switches the internal curve via `resolve_velocity_curve`. CC values may be
+single numbers or `[start, end]` lists which create linear envelopes across the
+section.
+
+The bow position is also emitted as CC71 (`tasto` → 20, `normale` → 64,
+`ponticello` → 100). A ``mute`` flag in `style_params` sends CC20 at 127 when
+enabled and 0 when disabled, reducing velocities slightly when no sampler
+support is available.
+
+``emotion_map`` entries map emotion/intensity pairs to expression map names. The
+defaults are stored in the same YAML and can be overridden:
+
+```yaml
+emotion_map:
+  default:
+    default: gentle_legato
+    high: marcato_drive
+```
+
+Controller numbers are configurable via `data/cc_map.yml`:
+
+```yaml
+expression: 11
+mod: 1
+bow_pressure: 2
+bow_position: 71
+mute_toggle: 20
+```

--- a/tests/data/ex_maps.yml
+++ b/tests/data/ex_maps.yml
@@ -1,0 +1,18 @@
+gentle_legato:
+  articulations: ["legato"]
+  cc:
+    1: 20
+    11: [40, 80]
+  velocity_curve_name: "soft"
+  mute_velocity_factor: 0.85
+marcato_drive:
+  articulations: ["accent", "detaché"]
+  cc:
+    1: 80
+    11: 90
+  velocity_curve_name: "hard"
+  mute_velocity_factor: 0.85
+emotion_map:
+  default:
+    default: gentle_legato
+    high: marcato_drive

--- a/tests/test_crescendo_helper.py
+++ b/tests/test_crescendo_helper.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from music21 import instrument
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("generator")
+pkg.__path__ = [str(ROOT / "generator")]
+sys.modules.setdefault("generator", pkg)
+
+_MOD_PATH = ROOT / "generator" / "strings_generator.py"
+spec = importlib.util.spec_from_file_location("generator.strings_generator", _MOD_PATH)
+strings_module = importlib.util.module_from_spec(spec)
+sys.modules["generator.strings_generator"] = strings_module
+spec.loader.exec_module(strings_module)
+StringsGenerator = strings_module.StringsGenerator
+
+
+def _gen(**kwargs):
+    return StringsGenerator(
+        global_settings={},
+        default_instrument=instrument.Violin(),
+        part_name="strings",
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        **kwargs,
+    )
+
+
+def test_crescendo_helper_sorted():
+    gen = _gen()
+    sec = {
+        "section_name": "A",
+        "q_length": 4.0,
+        "humanized_duration_beats": 4.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {},
+        "musical_intent": {},
+        "shared_tracks": {},
+    }
+    parts = gen.compose(section_data=sec)
+    gen.crescendo(parts, 4.0, start_val=30, end_val=90)
+    ecc = parts["violin_i"].extra_cc
+    assert len(ecc) >= 2
+    times = [e["time"] for e in ecc]
+    assert times == sorted(times)

--- a/tests/test_strings_expression_map.py
+++ b/tests/test_strings_expression_map.py
@@ -1,0 +1,52 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from music21 import instrument, articulations
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("generator")
+pkg.__path__ = [str(ROOT / "generator")]
+sys.modules.setdefault("generator", pkg)
+
+_MOD_PATH = ROOT / "generator" / "strings_generator.py"
+spec = importlib.util.spec_from_file_location("generator.strings_generator", _MOD_PATH)
+strings_module = importlib.util.module_from_spec(spec)
+sys.modules["generator.strings_generator"] = strings_module
+spec.loader.exec_module(strings_module)
+StringsGenerator = strings_module.StringsGenerator
+
+
+def _basic_section():
+    return {
+        "section_name": "A",
+        "q_length": 2.0,
+        "humanized_duration_beats": 2.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {},
+        "musical_intent": {},
+        "shared_tracks": {},
+    }
+
+
+def _gen(**kwargs):
+    return StringsGenerator(
+        global_settings={},
+        default_instrument=instrument.Violin(),
+        part_name="strings",
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        **kwargs,
+    )
+
+
+def test_expression_map_soft_legato():
+    gen = _gen(expression_maps_path=str(ROOT / "tests" / "data" / "ex_maps.yml"))
+    sec = _basic_section()
+    sec["part_params"] = {"strings": {"expression_map": "gentle_legato"}}
+    parts = gen.compose(section_data=sec)
+    cc_vals = [e["val"] for e in parts["violin_i"].extra_cc if e["cc"] == 1]
+    assert cc_vals and cc_vals[0] == 20

--- a/tests/test_strings_mute_bow_cc.py
+++ b/tests/test_strings_mute_bow_cc.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from music21 import instrument
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("generator")
+pkg.__path__ = [str(ROOT / "generator")]
+sys.modules.setdefault("generator", pkg)
+
+_MOD_PATH = ROOT / "generator" / "strings_generator.py"
+spec = importlib.util.spec_from_file_location("generator.strings_generator", _MOD_PATH)
+strings_module = importlib.util.module_from_spec(spec)
+sys.modules["generator.strings_generator"] = strings_module
+spec.loader.exec_module(strings_module)
+StringsGenerator = strings_module.StringsGenerator
+BowPosition = strings_module.BowPosition
+
+
+def _basic_section():
+    return {
+        "section_name": "A",
+        "q_length": 1.0,
+        "humanized_duration_beats": 1.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {},
+        "musical_intent": {},
+        "shared_tracks": {},
+    }
+
+
+def _gen(**kwargs):
+    return StringsGenerator(
+        global_settings={},
+        default_instrument=instrument.Violin(),
+        part_name="strings",
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        **kwargs,
+    )
+
+
+def test_mute_and_bow_cc():
+    gen = _gen()
+    sec = _basic_section()
+    sec["style_params"] = {"mute": True}
+    sec["events"] = [{"duration": 1.0, "bow_position": "sul pont."}]
+    parts = gen.compose(section_data=sec)
+    cc_vals = {(e["cc"], e["val"]) for e in parts["violin_i"].extra_cc}
+    assert (20, 127) in cc_vals
+    assert any(e["cc"] == 71 and e["val"] >= 99 for e in parts["violin_i"].extra_cc)

--- a/tests/test_strings_phase4.py
+++ b/tests/test_strings_phase4.py
@@ -1,0 +1,76 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from music21 import instrument
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("generator")
+pkg.__path__ = [str(ROOT / "generator")]
+sys.modules.setdefault("generator", pkg)
+
+_MOD_PATH = ROOT / "generator" / "strings_generator.py"
+spec = importlib.util.spec_from_file_location("generator.strings_generator", _MOD_PATH)
+strings_module = importlib.util.module_from_spec(spec)
+sys.modules["generator.strings_generator"] = strings_module
+spec.loader.exec_module(strings_module)
+StringsGenerator = strings_module.StringsGenerator
+cc_map = strings_module.cc_map
+load_cc_map = strings_module.load_cc_map
+
+
+def _basic_section(length=2.0):
+    return {
+        "section_name": "A",
+        "q_length": length,
+        "humanized_duration_beats": length,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {},
+        "musical_intent": {},
+        "shared_tracks": {},
+    }
+
+
+def _gen(**kwargs):
+    return StringsGenerator(
+        global_settings={},
+        default_instrument=instrument.Violin(),
+        part_name="strings",
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+        **kwargs,
+    )
+
+
+def test_unknown_emotion_fallback(tmp_path):
+    gen = _gen(expression_maps_path=str(ROOT / "tests" / "data" / "ex_maps.yml"))
+    sec = _basic_section()
+    sec["musical_intent"] = {"emotion": "mystery", "intensity": "extreme"}
+    parts = gen.compose(section_data=sec)
+    vals = [e["val"] for e in parts["violin_i"].extra_cc if e["cc"] == 1]
+    assert vals and vals[0] == 20
+
+
+def test_custom_cc_map_override(tmp_path):
+    path = tmp_path / "cc.yml"
+    path.write_text("mute_toggle: 21\n")
+    load_cc_map(str(path))
+    gen = _gen()
+    sec = _basic_section(1.0)
+    sec["style_params"] = {"mute": True}
+    parts = gen.compose(section_data=sec)
+    assert any(e["cc"] == 21 for e in parts["violin_i"].extra_cc)
+
+
+def test_crescendo_long_section():
+    gen = _gen()
+    sec = _basic_section(8.0)
+    parts = gen.compose(section_data=sec)
+    gen.crescendo(parts, 8.0, start_val=30, end_val=90)
+    vals = [e["val"] for e in parts["violin_i"].extra_cc if e["cc"] == cc_map["expression"]]
+    assert vals[0] == 30 and vals[-1] == 90
+    assert vals == sorted(vals)
+    assert len(vals) > 2

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -181,6 +181,7 @@ else:
             )
 from .install_utils import run_with_retry
 from . import mix_profile
+from .cc_map import cc_map, load_cc_map
 try:
     importlib.import_module("utilities.ir_renderer")
     from . import ir_renderer
@@ -251,6 +252,8 @@ __all__ = [
     "groove_sampler_ngram",
     "groove_sampler_rnn",
     "mix_profile",
+    "cc_map",
+    "load_cc_map",
     "ir_renderer",
     "load_ir",
     "convolve_ir",

--- a/utilities/cc_map.py
+++ b/utilities/cc_map.py
@@ -1,0 +1,44 @@
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+cc_map: Dict[str, int] = {}
+
+
+def _default_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "data" / "cc_map.yml"
+
+
+def load_cc_map(path: str | None = None) -> Dict[str, int]:
+    """Load CC number mapping from YAML/JSON file."""
+
+    if path is None:
+        path = os.environ.get("CC_MAP_PATH")
+    if not path:
+        path = str(_default_path())
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            if path.endswith(".json"):
+                data = json.load(fh)
+            else:
+                data = yaml.safe_load(fh)
+    except Exception as exc:  # pragma: no cover - optional
+        logger.warning("Failed to load CC map %s: %s", path, exc)
+        data = {}
+    if isinstance(data, dict):
+        for k, v in data.items():
+            try:
+                cc_map[str(k)] = int(v)
+            except Exception:
+                logger.debug("Invalid CC number for %s: %r", k, v)
+    return cc_map
+
+
+load_cc_map()
+

--- a/utilities/cc_tools.py
+++ b/utilities/cc_tools.py
@@ -97,10 +97,19 @@ def finalize_cc_events(part: stream.Part) -> list[dict]:
         delattr(part, "_extra_cc")
     return part.extra_cc
 
+
+def add_cc_events(part: stream.Part, events: TypingIterable[dict] | TypingIterable[CCEvent]) -> None:
+    """Merge CC events into ``part.extra_cc`` preserving order."""
+
+    base = getattr(part, "extra_cc", [])
+    merged = merge_cc_events(base, events)
+    part.extra_cc = to_sorted_dicts(merged)
+
 __all__ = [
     "merge_cc_events",
     "to_sorted_dicts",
     "finalize_cc_events",
+    "add_cc_events",
     "CCEvent",
 ]
 


### PR DESCRIPTION
## Summary
- externalize emotion/intensity defaults in `expression_maps.yml`
- add `data/cc_map.yml` and loader utility
- support configurable CC numbers and mute velocity factor
- implement easing curve for CC envelopes
- add regression tests for new options

## Testing
- `pytest tests/test_strings_expression_map.py tests/test_strings_mute_bow_cc.py tests/test_crescendo_helper.py tests/test_strings_phase4.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686b47e492c083288b6c952e141378be