### PR TITLE
Update docs and unify image path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Verify SF2 Size
         if: matrix.variant == 'PIANO_ML'
         run: ls -lh sf2/TimGM6mb.sf2
-      - name: Ruff
-        run: ruff check . --output-format=github
+      - name: Run ruff lint
+        run: ruff check .
       - name: Mypy
         run: mypy modular_composer utilities tests --strict
       - name: Debug music21
@@ -289,8 +289,12 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+      - name: Install test tools
+        run: pip install -e .[test]
       - name: Install dependencies
         run: pip install torch transformers peft
+      - name: Run ruff lint
+        run: ruff check .
       - name: Train tiny model
         run: python train_piano_lora.py --data tests/mini.jsonl --epochs 1 --out tmp_model --auto-hparam
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -952,6 +952,16 @@ python train_piano_lora.py --data piano.jsonl --out piano_model --auto-hparam
 modcompose sample dummy.pkl --backend piano_ml --model piano_model --temperature 0.9
 ```
 
+### Tokenizer export
+
+```bash
+python - <<'PY'
+from transformer.tokenizer_piano import PianoTokenizer
+tok = PianoTokenizer()
+tok.export_vocab("models/vocab.json")
+PY
+```
+
 ## DAW Plugin Prototype
 
 An experimental JUCE plugin bridges the Python engine via ``pybind11``.

--- a/docs/docs/img/piano_gamma_demo.png
+++ b/docs/docs/img/piano_gamma_demo.png
@@ -1,0 +1,1 @@
+placeholder

--- a/docs/piano_gamma.md
+++ b/docs/piano_gamma.md
@@ -30,7 +30,7 @@ modcompose sample dummy.pkl --backend piano_ml --model piano_model --temperature
 
 ## Example Screenshot
 
-![training placeholder](img/piano_gamma_demo.png)
+![training placeholder](docs/img/piano_gamma_demo.png)
 
 
 ## How to fine-tune with your WAV corpus

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,5 @@ soundfile>=0.12
 scipy>=1.10
 scikit-learn>=1.3
 mido>=1.3
+pretty_midi>=0.2
+websockets>=12.0  # test_ws_echo 用

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,5 @@ audio =
 test =
     scikit-learn>=1.3
     mido>=1.3
+    pretty_midi>=0.2
+    websockets>=12.0

--- a/transformer/piano_transformer.py
+++ b/transformer/piano_transformer.py
@@ -10,8 +10,8 @@ except Exception:  # pragma: no cover - optional
     nn = object  # type: ignore
 
 try:
-    from transformers import GPT2Config, GPT2LMHeadModel
     from peft import LoraConfig, TaskType, get_peft_model
+    from transformers import GPT2Config, GPT2LMHeadModel
 except Exception:  # pragma: no cover - optional
     GPT2Config = None  # type: ignore
     GPT2LMHeadModel = None  # type: ignore

--- a/transformer/tokenizer_piano.py
+++ b/transformer/tokenizer_piano.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Dict, List
 import json
 import warnings
+from typing import Dict, List
 
 
 class PianoTokenizer:


### PR DESCRIPTION
## Summary
- link images using the `docs/img` prefix
- add tokenizer export example in README
- run ruff lint in CI smoke job

## Testing
- `ruff check --select I --fix .`
- `mkdocs build -s`
- `pytest -q` *(fails: Missing packages: music21, pretty_midi, mido)*

------
https://chatgpt.com/codex/tasks/task_e_686b6c0bc9908328ab2a10077d6b8d5c