### PR TITLE
Add macro envelope tests and docs

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -86,4 +86,9 @@ part_params:
     timing_jitter_ms: 20
     timing_jitter_scale_mode: bpm_relative
     bow_position: tasto
+    macro_envelope:
+      type: cresc
+      beats: 4
+      start: 40
+      end: 90
 ```

--- a/tests/test_strings_expression.py
+++ b/tests/test_strings_expression.py
@@ -50,10 +50,18 @@ def test_base_dynamic_mf_vs_p():
     sec = _basic_section()
     sec["musical_intent"] = {"style": "ballad", "intensity": "soft"}
     parts_p = gen.compose(section_data=sec)
-    val_p = next(e["val"] for e in parts_p["violin_i"].extra_cc if e["cc"] == cc_map["expression"])
+    val_p = next(
+        e["val"]
+        for e in parts_p["violin_i"].extra_cc
+        if e["cc"] == cc_map["expression"]
+    )
     sec["musical_intent"] = {"style": "dramatic", "intensity": "high"}
     parts_mf = gen.compose(section_data=sec)
-    val_mf = next(e["val"] for e in parts_mf["violin_i"].extra_cc if e["cc"] == cc_map["expression"])
+    val_mf = next(
+        e["val"]
+        for e in parts_mf["violin_i"].extra_cc
+        if e["cc"] == cc_map["expression"]
+    )
     assert val_mf > val_p
 
 
@@ -62,7 +70,9 @@ def test_crescendo_curve():
     sec = _basic_section(4.0)
     parts = gen.compose(section_data=sec)
     gen.crescendo(parts, 4.0, start_val=40, end_val=90)
-    vals = [e["val"] for e in parts["violin_i"].extra_cc if e["cc"] == cc_map["expression"]]
+    vals = [
+        e["val"] for e in parts["violin_i"].extra_cc if e["cc"] == cc_map["expression"]
+    ]
     assert len(vals) >= 3
     assert vals == sorted(vals)
 
@@ -72,7 +82,9 @@ def test_diminuendo_macro():
     sec = _basic_section(4.0)
     parts = gen.compose(section_data=sec)
     gen.diminuendo(parts, 4.0, start_val=90, end_val=30)
-    vals = [e["val"] for e in parts["violin_i"].extra_cc if e["cc"] == cc_map["expression"]]
+    vals = [
+        e["val"] for e in parts["violin_i"].extra_cc if e["cc"] == cc_map["expression"]
+    ]
     assert vals[0] == 90 and vals[-1] == 30
     assert vals == sorted(vals, reverse=True)
 
@@ -85,3 +97,53 @@ def test_mute_cc_from_map():
     parts = gen.compose(section_data=sec)
     vals = [e for e in parts["violin_i"].extra_cc if e["cc"] == cc_map["mute_toggle"]]
     assert vals and vals[0]["val"] == 64
+
+
+def test_macro_envelope_crescendo():
+    gen = _gen()
+    sec = _basic_section(4.0)
+    sec["part_params"] = {
+        "macro_envelope": {"type": "cresc", "beats": 4.0, "start": 40, "end": 90}
+    }
+    parts = gen.compose(section_data=sec)
+    vals = [
+        e["val"] for e in parts["violin_i"].extra_cc if e["cc"] == cc_map["expression"]
+    ]
+    assert vals[0] == 40 and vals[-1] == 90
+    assert vals == sorted(vals)
+
+
+def test_macro_envelope_diminuendo():
+    gen = _gen()
+    sec = _basic_section(4.0)
+    sec["part_params"] = {
+        "macro_envelope": {"type": "dim", "beats": 4.0, "start": 90, "end": 50}
+    }
+    parts = gen.compose(section_data=sec)
+    vals = [
+        e["val"] for e in parts["violin_i"].extra_cc if e["cc"] == cc_map["expression"]
+    ]
+    assert vals[0] == 90 and vals[-1] == 50
+    assert vals == sorted(vals, reverse=True)
+
+
+def test_diminuendo_alias():
+    gen = _gen()
+    sec = _basic_section(4.0)
+    parts_a = gen.compose(section_data=sec)
+    gen.diminuendo(parts_a, 4.0, start_val=80, end_val=30)
+    vals_a = [
+        e["val"]
+        for e in parts_a["violin_i"].extra_cc
+        if e["cc"] == cc_map["expression"]
+    ]
+
+    parts_b = gen.compose(section_data=sec)
+    gen.apply_dim(parts_b, 4.0, start_val=80, end_val=30)
+    vals_b = [
+        e["val"]
+        for e in parts_b["violin_i"].extra_cc
+        if e["cc"] == cc_map["expression"]
+    ]
+
+    assert vals_a == vals_b


### PR DESCRIPTION
## Summary
- document `macro_envelope` usage in quick start
- test automatic crescendo/diminuendo via `macro_envelope`
- verify `diminuendo` is an alias for `apply_dim`

## Testing
- `pytest -q tests/test_strings_expression.py::test_macro_envelope_crescendo tests/test_strings_expression.py::test_macro_envelope_diminuendo tests/test_strings_expression.py::test_diminuendo_alias tests/test_strings_mute_bow_cc.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686c49ffcfd883289f7806097e9b3672