### PR TITLE
Fix async test deps

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,7 @@ markers =
     velocity: velocity expression tests
     eval: evaluation tests
     plugin: plugin tests
+    asyncio: mark tests to run with pytest-asyncio
 
 [tool:pytest]
 filterwarnings =

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 hypothesis>=6
 mido>=1.2
 librosa>=0.10
+httpx>=0.23.3
+pytest-asyncio>=0.20.3


### PR DESCRIPTION
## Summary
- install httpx and pytest-asyncio for dev
- register asyncio marker in pytest.ini

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c58dfffa08328b1311e83b3a780fc