### PR TITLE
Add sax companion API

### DIFF
--- a/api/sax_server.py
+++ b/api/sax_server.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Simple FastAPI server exposing sax solo generation."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+try:
+    import plugins.sax_companion_plugin as sax_plugin
+except Exception:  # pragma: no cover - plugin not built
+    import plugins.sax_companion_stub as sax_plugin  # type: ignore
+
+app = FastAPI()
+
+
+class SaxRequest(BaseModel):
+    growl: bool = False
+    altissimo: bool = False
+
+
+@app.post("/generate_sax")
+def generate_sax(req: SaxRequest) -> list[dict[str, object]]:
+    """Return sax notes using plugin or stub."""
+    return sax_plugin.generate_notes(req.model_dump())

--- a/generator/sax_generator.py
+++ b/generator/sax_generator.py
@@ -1,5 +1,67 @@
+from __future__ import annotations
+
+"""Saxophone phrasing generator."""
+
+from typing import Any
+
+from utilities.scale_registry import ScaleRegistry
+from utilities.cc_tools import add_cc_events
+
+from music21 import instrument, articulations, spanner, stream
+import math
+
 from .melody_generator import MelodyGenerator
-from music21 import instrument
+
+
+DEFAULT_PHRASE_PATTERNS: dict[str, dict[str, Any]] = {
+    "sax_basic_swing": {
+        "description": "Simple 8th‑note swing phrase (2 bars)",
+        "pattern": [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            2.5,
+            3.0,
+            3.5,
+            4.0,
+            4.5,
+            5.0,
+            5.5,
+            6.0,
+            6.5,
+            7.0,
+            7.5,
+        ],
+        "note_duration_ql": 0.5,
+        "reference_duration_ql": 8.0,
+    },
+    "sax_syncopated": {
+        "description": "Syncopated phrase with rests",
+        "pattern": [0.0, 1.0, 1.5, 2.5, 3.0, 4.0, 4.5, 5.75, 6.25, 7.0],
+        "note_duration_ql": 0.5,
+        "reference_duration_ql": 8.0,
+    },
+}
+
+EMOTION_TO_BUCKET: dict[str, str] = {
+    "default": "basic",
+}
+
+BUCKET_TO_PATTERN: dict[tuple[str, str], str] = {
+    ("basic", "low"): "sax_basic_swing",
+    ("basic", "medium"): "sax_basic_swing",
+    ("basic", "high"): "sax_syncopated",
+}
+
+BREATH_CC = 2
+MOD_CC = 1
+PITCHWHEEL = -1  # stored in extra_cc as negative CC number
+
+STACCATO_VAL = 30
+LEGATO_VAL = 90
+SLUR_VAL = 80
 
 
 class SaxGenerator(MelodyGenerator):
@@ -7,4 +69,89 @@ class SaxGenerator(MelodyGenerator):
 
     def __init__(self, **kwargs):
         kwargs.setdefault("instrument_name", "Alto Saxophone")
+        rh_lib = kwargs.setdefault("rhythm_library", {})
+        for k, v in DEFAULT_PHRASE_PATTERNS.items():
+            rh_lib.setdefault(k, v)
         super().__init__(**kwargs)
+
+    # ------------------------------------------------------------------
+    # CC Helpers
+    # ------------------------------------------------------------------
+    def _apply_articulation_cc(self, part: stream.Part) -> None:
+        """Add CC1/CC2 events based on articulations."""
+        events = []
+        notes = sorted(part.recurse().notes, key=lambda n: n.offset)
+        prev_end = None
+        for n in notes:
+            off = float(n.offset)
+            is_stacc = any(isinstance(a, articulations.Staccato) for a in n.articulations)
+            has_slur = any(isinstance(s, spanner.Slur) and n in s for s in part.recurse().getElementsByClass(spanner.Slur))
+            if is_stacc:
+                val = STACCATO_VAL
+                events.append((off, MOD_CC, val))
+            elif has_slur or (prev_end is not None and abs(off - prev_end) < 1e-3):
+                val = LEGATO_VAL
+                events.append((off, BREATH_CC, val))
+            else:
+                events.append((off, BREATH_CC, SLUR_VAL))
+            prev_end = off + float(n.quarterLength)
+        add_cc_events(part, events)
+
+    def _apply_vibrato(self, part: stream.Part, depth: float = 200.0, rate_hz: float = 5.0) -> None:
+        """Approximate vibrato using pitch wheel events."""
+        events = []
+        bpm = float(self.global_tempo or 120.0)
+        for n in part.recurse().notes:
+            dur_sec = float(n.quarterLength) * 60.0 / bpm
+            step = 0.1
+            t = 0.0
+            while t <= dur_sec + 1e-6:
+                val = int(8192 + depth * math.sin(2 * math.pi * rate_hz * t))
+                events.append((float(n.offset) + t * bpm / 60.0, PITCHWHEEL, val))
+                t += step
+        add_cc_events(part, events)
+
+    # ------------------------------------------------------------------
+    # Pattern Selection Helpers
+    # ------------------------------------------------------------------
+    def _choose_pattern_key(
+        self,
+        emotion: str | None,
+        intensity: str | None,
+        musical_intent: dict[str, Any] | None = None,
+    ) -> str:
+        emo = (emotion or "default").lower()
+        inten = (intensity or "medium").lower()
+        bucket = EMOTION_TO_BUCKET.get(emo, "basic")
+        return BUCKET_TO_PATTERN.get((bucket, inten), "sax_basic_swing")
+
+    def compose(self, section_data=None):  # type: ignore[override]
+        if section_data:
+            mi = section_data.get("musical_intent", {})
+            pat_key = self._choose_pattern_key(
+                mi.get("emotion"), mi.get("intensity"), mi
+            )
+            section_data.setdefault("part_params", {}).setdefault("melody", {})[
+                "rhythm_key"
+            ] = pat_key
+        part = super().compose(section_data)
+        tonic = (
+            section_data.get("tonic_of_section")
+            if section_data else self.global_key_signature_tonic
+        )
+        mode = (
+            section_data.get("mode")
+            if section_data else self.global_key_signature_mode
+        )
+        pcs = {
+            p.pitchClass
+            for p in ScaleRegistry.get(tonic or "C", mode or "major").getPitches(
+                "C3", "C5"
+            )
+        }
+        for n in list(part.recurse().notes):
+            if n.pitch.pitchClass not in pcs:
+                part.remove(n)
+        self._apply_articulation_cc(part)
+        self._apply_vibrato(part)
+        return part

--- a/plugins/sax_companion/CMakeLists.txt
+++ b/plugins/sax_companion/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.15)
+project(sax_companion_plugin)
+
+if(MODC_BUILD_PLUGIN)
+  add_subdirectory(juce)
+  juce_add_plugin(SaxCompanion
+    COMPANY_NAME "ModCompose"
+    PLUGIN_NAME  "SaxCompanion"
+    FORMATS      VST3 CLAP
+    SOURCES
+      PluginProcessor.cpp
+      PluginProcessor.h
+      PluginEditor.cpp
+      PluginEditor.h
+      plugin.cpp
+      ringbuffer.h
+  )
+  target_link_libraries(SaxCompanion PRIVATE pybind11::embed)
+else()
+  pybind11_add_module(sax_companion_plugin plugin.cpp)
+  set_target_properties(sax_companion_plugin PROPERTIES PREFIX "" OUTPUT_NAME "sax_companion_plugin")
+endif()

--- a/plugins/sax_companion/PluginEditor.cpp
+++ b/plugins/sax_companion/PluginEditor.cpp
@@ -1,0 +1,18 @@
+#include "PluginEditor.h"
+#include "PluginProcessor.h"
+
+SaxCompanionAudioProcessorEditor::SaxCompanionAudioProcessorEditor(SaxCompanionAudioProcessor& p)
+    : juce::AudioProcessorEditor(p), processor(p) {
+    addAndMakeVisible(growlButton);
+    addAndMakeVisible(altissimoButton);
+    setSize(400, 100);
+}
+
+SaxCompanionAudioProcessorEditor::~SaxCompanionAudioProcessorEditor() {}
+
+void SaxCompanionAudioProcessorEditor::resized() {
+    auto area = getLocalBounds();
+    growlButton.setBounds(area.removeFromLeft(190).reduced(5));
+    altissimoButton.setBounds(area.reduced(5));
+}
+

--- a/plugins/sax_companion/PluginEditor.h
+++ b/plugins/sax_companion/PluginEditor.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <juce_gui_extra/juce_gui_extra.h>
+
+class SaxCompanionAudioProcessor;
+
+class SaxCompanionAudioProcessorEditor : public juce::AudioProcessorEditor {
+public:
+    explicit SaxCompanionAudioProcessorEditor(SaxCompanionAudioProcessor&);
+    ~SaxCompanionAudioProcessorEditor() override;
+
+    void paint(juce::Graphics&) override {}
+    void resized() override {}
+
+private:
+    juce::TextButton growlButton{"Growl"};
+    juce::TextButton altissimoButton{"Altissimo"};
+    SaxCompanionAudioProcessor& processor;
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SaxCompanionAudioProcessorEditor)
+};

--- a/plugins/sax_companion/PluginProcessor.cpp
+++ b/plugins/sax_companion/PluginProcessor.cpp
@@ -1,0 +1,10 @@
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+SaxCompanionAudioProcessor::SaxCompanionAudioProcessor() {}
+SaxCompanionAudioProcessor::~SaxCompanionAudioProcessor() {}
+
+juce::AudioProcessorEditor* SaxCompanionAudioProcessor::createEditor() {
+    return new SaxCompanionAudioProcessorEditor(*this);
+}
+

--- a/plugins/sax_companion/PluginProcessor.h
+++ b/plugins/sax_companion/PluginProcessor.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <juce_audio_processors/juce_audio_processors.h>
+
+class SaxCompanionAudioProcessor : public juce::AudioProcessor {
+public:
+    SaxCompanionAudioProcessor();
+    ~SaxCompanionAudioProcessor() override;
+
+    void prepareToPlay(double, int) override {}
+    void releaseResources() override {}
+    bool isBusesLayoutSupported(const BusesLayout&) const override { return true; }
+    void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) override {}
+
+    juce::AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override { return true; }
+
+    const juce::String getName() const override { return "SaxCompanion"; }
+    double getTailLengthSeconds() const override { return 0.0; }
+
+    int getNumPrograms() override { return 1; }
+    int getCurrentProgram() override { return 0; }
+    void setCurrentProgram(int) override {}
+    const juce::String getProgramName(int) override { return {}; }
+    void changeProgramName(int, const juce::String&) override {}
+
+    void getStateInformation(juce::MemoryBlock&) override {}
+    void setStateInformation(const void*, int) override {}
+
+private:
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SaxCompanionAudioProcessor)
+};

--- a/plugins/sax_companion/plugin.cpp
+++ b/plugins/sax_companion/plugin.cpp
@@ -1,0 +1,16 @@
+#include <pybind11/embed.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+std::vector<py::dict> generateSax(py::dict options) {
+    py::gil_scoped_acquire guard{};
+    py::object stub = py::module_::import("plugins.sax_companion_stub");
+    py::object func = stub.attr("generate_notes");
+    py::object res = func(options);
+    return res.cast<std::vector<py::dict>>();
+}
+
+PYBIND11_MODULE(sax_companion_plugin, m) {
+    m.def("generateSax", &generateSax);
+}

--- a/plugins/sax_companion/ringbuffer.h
+++ b/plugins/sax_companion/ringbuffer.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <vector>
+#include <cstddef>
+
+template <typename T>
+class RingBuffer {
+public:
+    explicit RingBuffer(std::size_t size) : buffer(size) {}
+
+    bool push(const T& item) {
+        auto next = (head + 1) % buffer.size();
+        if (next == tail)
+            return false;
+        buffer[head] = item;
+        head = next;
+        return true;
+    }
+
+    bool pop(T& item) {
+        if (tail == head)
+            return false;
+        item = buffer[tail];
+        tail = (tail + 1) % buffer.size();
+        return true;
+    }
+
+private:
+    std::vector<T> buffer;
+    std::size_t head{0};
+    std::size_t tail{0};
+};

--- a/plugins/sax_companion_stub.py
+++ b/plugins/sax_companion_stub.py
@@ -1,0 +1,18 @@
+"""Fallback stub used when the JUCE plugin is not built."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def generate_notes(opts: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    """Return a static note with growl/altissimo flags."""
+    opts = opts or {}
+    return [
+        {
+            "note": 60 if not opts.get("altissimo") else 72,
+            "growl": bool(opts.get("growl")),
+            "velocity": 100,
+            "offset": 0.0,
+        }
+    ]

--- a/tests/test_sax_articulation.py
+++ b/tests/test_sax_articulation.py
@@ -1,0 +1,36 @@
+import pytest
+from music21 import instrument, articulations, spanner
+
+from generator.sax_generator import SaxGenerator, BREATH_CC, MOD_CC
+
+
+def test_cc_events_for_articulations():
+    gen = SaxGenerator(
+        default_instrument=instrument.AltoSaxophone(),
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+    )
+
+    section = {
+        "section_name": "A",
+        "absolute_offset": 0.0,
+        "q_length": 4.0,
+        "chord_label": "C",
+        "part_params": {},
+        "musical_intent": {"emotion": "default", "intensity": "medium"},
+        "tonic_of_section": "C",
+        "mode": "major",
+    }
+
+    part = gen.compose(section_data=section)
+    notes = list(part.flatten().notes)
+    assert len(notes) >= 2
+    notes[0].articulations.append(articulations.Staccato())
+    sl = spanner.Slur(notes[1])
+    part.insert(notes[1].offset, sl)
+    gen._apply_articulation_cc(part)
+    events = getattr(part, "extra_cc", [])
+    assert any(e["cc"] == MOD_CC for e in events)
+    assert any(e["cc"] == BREATH_CC for e in events)

--- a/tests/test_sax_plugin_api.py
+++ b/tests/test_sax_plugin_api.py
@@ -1,0 +1,20 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+from api.sax_server import app
+
+
+def test_stub_generation() -> None:
+    mod = importlib.import_module("plugins.sax_companion_stub")
+    notes = mod.generate_notes({"growl": True})
+    assert notes[0]["growl"] is True
+
+
+def test_api_endpoint() -> None:
+    client = TestClient(app)
+    resp = client.post("/generate_sax", json={"growl": False, "altissimo": True})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data[0]["note"] == 72

--- a/tests/test_sax_tokenizer.py
+++ b/tests/test_sax_tokenizer.py
@@ -1,0 +1,19 @@
+from transformer.sax_tokenizer import SaxTokenizer
+
+
+def test_round_trip_with_artic() -> None:
+    tok = SaxTokenizer()
+    events = [
+        {"bar": 0, "note": 60, "artic": "slide_up"},
+        {"bar": 1, "note": 62, "artic": "alt_hit"},
+    ]
+    ids = tok.encode(events)
+    decoded = tok.decode(ids)
+    assert decoded == events
+
+
+def test_special_tokens_exist() -> None:
+    tok = SaxTokenizer()
+    assert "<SLIDE_UP>" in tok.vocab
+    assert "<SLIDE_DOWN>" in tok.vocab
+    assert "<ALT_HIT>" in tok.vocab

--- a/tests/test_sax_transformer.py
+++ b/tests/test_sax_transformer.py
@@ -1,0 +1,16 @@
+import importlib.util
+import pytest
+
+transformers_available = importlib.util.find_spec("transformers") is not None
+peft_available = importlib.util.find_spec("peft") is not None
+
+
+@pytest.mark.skipif(not (transformers_available and peft_available), reason="missing transformers or peft")
+def test_sax_transformer_params() -> None:
+    from transformer.sax_transformer import SaxTransformer
+
+    model = SaxTransformer(vocab_size=100)
+    total = sum(p.numel() for p in model.parameters())
+    assert total > 0
+    lora_params = [n for n, _ in model.named_parameters() if "lora" in n]
+    assert lora_params

--- a/train_sax_lora.py
+++ b/train_sax_lora.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Train :class:`SaxTransformer` on a MIDI corpus using LoRA."""
+
+import argparse
+import json
+from pathlib import Path
+
+try:
+    import torch
+    from torch.utils.data import DataLoader, Dataset
+    from transformers import Trainer, TrainingArguments
+except Exception:  # pragma: no cover - optional
+    torch = None  # type: ignore
+    Dataset = object  # type: ignore
+    DataLoader = object  # type: ignore
+    Trainer = object  # type: ignore
+    TrainingArguments = object  # type: ignore
+
+from transformer.sax_transformer import SaxTransformer
+from transformer.sax_tokenizer import SaxTokenizer
+
+
+class JsonlDataset(Dataset):
+    def __init__(self, path: Path) -> None:
+        self.items: list[list[int]] = []
+        for line in path.read_text().splitlines():
+            obj = json.loads(line)
+            tokens = obj.get("ids") or obj.get("tokens")
+            if tokens is not None:
+                self.items.append(tokens)
+
+    def __len__(self) -> int:  # pragma: no cover - simple container
+        return len(self.items)
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:  # pragma: no cover - simple container
+        return {"input_ids": torch.tensor(self.items[idx], dtype=torch.long)}
+
+
+def collate_fn(batch: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:  # pragma: no cover - simple
+    lengths = [len(x["input_ids"]) for x in batch]
+    max_len = max(lengths)
+    pad_id = 0
+    input_ids = torch.full((len(batch), max_len), pad_id, dtype=torch.long)
+    for i, x in enumerate(batch):
+        seq = x["input_ids"]
+        input_ids[i, : len(seq)] = seq
+    labels = input_ids.clone()
+    return {"input_ids": input_ids, "labels": labels}
+
+
+def main() -> None:
+    if torch is None:
+        raise RuntimeError("Install torch and transformers to run training")
+
+    parser = argparse.ArgumentParser(description="Train SaxTransformer with LoRA")
+    parser.add_argument("--data", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--rank", type=int, default=4, help="LoRA rank")
+    parser.add_argument("--steps", type=int, default=800, help="Training steps")
+    parser.add_argument("--epochs", type=int, default=None, help="Training epochs")
+    parser.add_argument(
+        "--auto-hparam",
+        action="store_true",
+        help="auto scale LoRA rank and steps based on dataset size",
+    )
+    args = parser.parse_args()
+
+    n_samples = sum(1 for _ in open(args.data))
+    if args.auto_hparam:
+        if n_samples < 10_000:
+            args.rank = 4
+            args.steps = 800
+        elif n_samples < 30_000:
+            args.rank = 8
+            args.steps = 1_200
+        else:
+            args.rank = 16
+            args.steps = 2_000
+
+    if args.epochs is not None:
+        args.steps = args.epochs * n_samples
+
+    dataset = JsonlDataset(args.data)
+    tokenizer = SaxTokenizer()
+    model = SaxTransformer(vocab_size=len(tokenizer.vocab), rank=args.rank)
+
+    training_args = TrainingArguments(
+        output_dir=str(args.out),
+        per_device_train_batch_size=1,
+        max_steps=args.steps,
+        logging_steps=10,
+        save_steps=50,
+    )
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset,
+        data_collator=collate_fn,
+    )
+    trainer.train()
+    model.model.save_pretrained(str(args.out))
+
+
+if __name__ == "__main__":
+    main()

--- a/transformer/sax_tokenizer.py
+++ b/transformer/sax_tokenizer.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Tokenizer for saxophone MIDI events."""
+
+import json
+import warnings
+
+
+class SaxTokenizer:
+    """Minimal tokenizer for sax events with slide and alt-hit tokens."""
+
+    def __init__(self) -> None:
+        specials = [
+            "<BAR>",
+            "<TS_4_4>",
+            "<SLIDE_UP>",
+            "<SLIDE_DOWN>",
+            "<ALT_HIT>",
+            "<REST_d8>",
+            "<VELO_80>",
+            "<UNK>",
+        ]
+        pitches = [f"P{i}" for i in range(60, 97)]
+        self.vocab = specials + pitches
+        self.token_to_id: dict[str, int] = {tok: i for i, tok in enumerate(self.vocab)}
+        self.id_to_token: dict[int, str] = {i: tok for i, tok in enumerate(self.vocab)}
+
+    def export_vocab(self, path: str) -> None:
+        """Write ``self.vocab`` to ``path`` as JSON list."""
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(self.vocab, fh)
+
+    def encode(self, events: list[dict[str, object]]) -> list[int]:
+        tokens: list[int] = [self.token_to_id["<TS_4_4>"]]
+        current_bar = -1
+        unk = 0
+        for ev in events:
+            bar = int(ev.get("bar", 0))
+            while bar > current_bar:
+                tokens.append(self.token_to_id["<BAR>"])
+                current_bar += 1
+            pitch_token = f"P{int(ev.get('note', 60))}"
+            if pitch_token in self.token_to_id:
+                tokens.append(self.token_to_id[pitch_token])
+            else:
+                tokens.append(self.token_to_id["<UNK>"])
+                unk += 1
+            tech = str(ev.get("artic", "")).lower()
+            if tech == "slide_up":
+                tokens.append(self.token_to_id["<SLIDE_UP>"])
+            elif tech == "slide_down":
+                tokens.append(self.token_to_id["<SLIDE_DOWN>"])
+            elif tech == "alt_hit":
+                tokens.append(self.token_to_id["<ALT_HIT>"])
+            tokens.append(self.token_to_id["<VELO_80>"])
+        if unk / max(1, len(tokens)) > 0.01:
+            warnings.warn(f"unk token rate {unk/len(tokens):.2%}")
+        return tokens
+
+    def decode(self, ids: list[int]) -> list[dict[str, object]]:
+        events: list[dict[str, object]] = []
+        bar = -1
+        i = 0
+        while i < len(ids):
+            tok = self.id_to_token[ids[i]]
+            if tok == "<TS_4_4>":
+                bar = -1
+                i += 1
+                continue
+            if tok == "<BAR>":
+                bar += 1
+                i += 1
+                continue
+            if tok.startswith("P"):
+                pitch = int(tok[1:])
+                i += 1
+                artic = None
+                if i < len(ids):
+                    next_tok = self.id_to_token[ids[i]]
+                    if next_tok == "<SLIDE_UP>":
+                        artic = "slide_up"
+                        i += 1
+                    elif next_tok == "<SLIDE_DOWN>":
+                        artic = "slide_down"
+                        i += 1
+                    elif next_tok == "<ALT_HIT>":
+                        artic = "alt_hit"
+                        i += 1
+                if i < len(ids) and self.id_to_token[ids[i]] == "<VELO_80>":
+                    i += 1
+                ev = {"bar": bar, "note": pitch}
+                if artic:
+                    ev["artic"] = artic
+                events.append(ev)
+                continue
+            i += 1
+        return events
+
+
+__all__ = ["SaxTokenizer"]

--- a/transformer/sax_transformer.py
+++ b/transformer/sax_transformer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""GPT-2 based transformer with LoRA for saxophone events."""
+
+try:
+    import torch
+    from torch import nn
+except Exception:  # pragma: no cover - optional
+    torch = None  # type: ignore
+    nn = object  # type: ignore
+
+try:
+    from peft import LoraConfig, TaskType, get_peft_model
+    from transformers import GPT2Config, GPT2LMHeadModel
+except Exception:  # pragma: no cover - optional
+    GPT2Config = None  # type: ignore
+    GPT2LMHeadModel = None  # type: ignore
+    LoraConfig = None  # type: ignore
+    TaskType = None  # type: ignore
+    get_peft_model = None  # type: ignore
+
+
+class SaxTransformer(nn.Module if torch is not None else object):
+    """LoRA-equipped GPT-2 transformer for saxophone tokens."""
+
+    def __init__(self, vocab_size: int, rank: int = 4) -> None:
+        if GPT2Config is None or GPT2LMHeadModel is None or get_peft_model is None or torch is None:
+            raise RuntimeError("Install torch, transformers and peft to use SaxTransformer")
+        super().__init__()
+        config = GPT2Config(vocab_size=vocab_size, n_layer=8, n_head=8, n_embd=512)
+        base = GPT2LMHeadModel(config)
+        lora_cfg = LoraConfig(task_type=TaskType.CAUSAL_LM, r=rank, lora_alpha=16, target_modules=["c_attn"], inference_mode=False)
+        self.model = get_peft_model(base, lora_cfg)
+
+    def forward(self, input_ids: torch.Tensor, past_key_values: tuple[tuple[torch.Tensor, ...], ...] | None = None) -> torch.Tensor:
+        if torch is None:
+            raise RuntimeError("torch not available")
+        outputs = self.model(input_ids=input_ids, past_key_values=past_key_values, use_cache=True)
+        return outputs.logits
+
+
+__all__ = ["SaxTransformer"]


### PR DESCRIPTION
## Summary
- add sax companion JUCE plugin skeleton with Growl/Altissimo controls
- provide Python stub `sax_companion_stub.py`
- implement FastAPI server `/generate_sax`
- test stub and API behavior

## Testing
- `pytest tests/test_sax_plugin_api.py -q`
- `pytest -q` *(fails: 9 failed, 490 passed, 27 skipped, 1 xpassed)*

------
https://chatgpt.com/codex/tasks/task_e_686c4afa27288328abf0279448716850