### PR TITLE
Add API test deps

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,8 @@ scikit-learn>=1.3
 mido>=1.3
 pretty_midi>=0.2
 websockets>=12.0  # test_ws_echo 用
+
+fastapi>=0.85
+httpx>=0.23
+pytest-asyncio>=0.20
+starlette>=0.25

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,7 @@ test =
     mido>=1.3
     pretty_midi>=0.2
     websockets>=12.0
+    fastapi>=0.85
+    httpx>=0.23
+    pytest-asyncio>=0.20
+    starlette>=0.25


### PR DESCRIPTION
## Summary
- add FastAPI, HTTPX, pytest-asyncio, and Starlette to test requirements
- expose these packages in the `[test]` extras

## Testing
- `pip install fastapi httpx pytest-asyncio starlette`
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686c67a09c308328b83001f8a089274f