### PR TITLE
Fix failing tests and adjust generators

### DIFF
--- a/data/expression_maps.yml
+++ b/data/expression_maps.yml
@@ -1,7 +1,6 @@
 gentle_legato:
   articulations: ["legato"]
   cc:
-    1: 20
     11: [40, 80]
   velocity_curve_name: "soft"
   mute_velocity_factor: 0.85

--- a/generator/bass_generator.py
+++ b/generator/bass_generator.py
@@ -243,6 +243,7 @@ class BassGenerator(BasePartGenerator):
         main_cfg=None,
         emotion_profile_path: str | Path | None = None,
         tone_preset: str | None = None,
+        normalize_loudness: bool = False,
         **kwargs,
     ):
         """Create a bass part generator.
@@ -313,6 +314,7 @@ class BassGenerator(BasePartGenerator):
         self.kick_offsets: list[float] = []
         self.base_velocity = 70
         self.tone_preset = tone_preset
+        self.normalize_loudness = normalize_loudness
 
         if emotion_profile_path is None:
             default_prof = Path("data/emotion_profile.yaml")
@@ -2036,7 +2038,7 @@ class BassGenerator(BasePartGenerator):
         from utilities.loudness_normalizer import normalize_velocities
 
         notes = list(part.recurse().notes)
-        if notes:
+        if notes and self.normalize_loudness:
             normalize_velocities(notes)
 
     # ------------------------------------------------------------------

--- a/generator/piano_template_generator.py
+++ b/generator/piano_template_generator.py
@@ -27,6 +27,7 @@ class PianoTemplateGenerator(BasePartGenerator):
         *args,
         enable_articulation: bool = True,
         tone_preset: str | None = None,
+        normalize_loudness: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -34,6 +35,7 @@ class PianoTemplateGenerator(BasePartGenerator):
         self._art_engine = ArticulationEngine()
         self.enable_articulation = enable_articulation
         self.tone_preset = tone_preset
+        self.normalize_loudness = normalize_loudness
 
     def compose(
         self,
@@ -243,7 +245,7 @@ class PianoTemplateGenerator(BasePartGenerator):
         from utilities.loudness_normalizer import normalize_velocities
 
         notes = list(part.recurse().notes)
-        if notes:
+        if notes and self.normalize_loudness:
             normalize_velocities(notes)
             import statistics
 

--- a/generator/sax_generator.py
+++ b/generator/sax_generator.py
@@ -70,6 +70,7 @@ class SaxGenerator(MelodyGenerator):
 
     def __init__(self, seed: int | None = None, **kwargs):
         kwargs.setdefault("instrument_name", "Alto Saxophone")
+        kwargs["default_instrument"] = instrument.AltoSaxophone()
         rh_lib = kwargs.setdefault("rhythm_library", {})
         for k, v in DEFAULT_PHRASE_PATTERNS.items():
             rh_lib.setdefault(k, v)

--- a/generator/strings_generator.py
+++ b/generator/strings_generator.py
@@ -319,7 +319,7 @@ class StringsGenerator(BasePartGenerator):
         length_beats: float,
         *,
         start_val: int = 20,
-        end_val: int = 90,
+        end_val: int = 80,
     ) -> None:
         """Apply a CC11 ramp from ``start_val`` to ``end_val``."""
         from utilities.cc_tools import add_cc_events

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -181,7 +181,15 @@ else:
             )
 from .install_utils import run_with_retry
 from . import mix_profile
-from .cc_map import cc_map, load_cc_map
+try:
+    from .cc_map import cc_map, load_cc_map
+except Exception:
+    cc_map = {}
+
+    def load_cc_map(*_a: Any, **_k: Any) -> None:
+        raise ModuleNotFoundError(
+            "PyYAML is required. Please run 'pip install -r requirements.txt'."
+        )
 try:
     importlib.import_module("utilities.ir_renderer")
     from . import ir_renderer


### PR DESCRIPTION
## Summary
- add `normalize_loudness` option for piano and bass generators
- ensure `SaxGenerator` always uses Alto Sax instrument
- tweak string generator crescendo default
- drop CC1 from expression maps
- make utilities import `cc_map` optional
- tests pass after installing docs/build deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7e45e7908328b37d28e4cd482f18