### PR TITLE
Implement lyric mismatch warnings

### DIFF
--- a/tests/test_vocal_lyrics.py
+++ b/tests/test_vocal_lyrics.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from music21 import note
 from generator.vocal_generator import VocalGenerator
@@ -14,4 +15,48 @@ def test_assign_lyrics_to_notes():
     part = gen.compose(midivocal_data, processed_chord_stream=[], humanize_opt=False, lyrics_words=["あい", "あい"])
     lyrics = [n.lyric for n in part.flatten().notes]
     assert lyrics == ["あ", "い", "あ", "い"]
+
+
+def test_single_word_two_notes():
+    gen = VocalGenerator()
+    midivocal_data = [
+        {"offset": 0.0, "pitch": "C4", "length": 2.0, "velocity": 80},
+        {"offset": 2.0, "pitch": "D4", "length": 2.0, "velocity": 80},
+    ]
+    part = gen.compose(midivocal_data, processed_chord_stream=[], humanize_opt=False, lyrics_words=["あい"])
+    lyrics = [n.lyric for n in part.flatten().notes]
+    assert lyrics == ["あ", "い"]
+
+
+def test_vocal_lyrics_empty(caplog):
+    gen = VocalGenerator()
+    midivocal_data = [
+        {"offset": 0.0, "pitch": "C4", "length": 1.0, "velocity": 80},
+        {"offset": 1.0, "pitch": "D4", "length": 1.0, "velocity": 80},
+    ]
+    with caplog.at_level(logging.WARNING):
+        part = gen.compose(
+            midivocal_data, processed_chord_stream=[], humanize_opt=False, lyrics_words=[]
+        )
+    lyrics = [n.lyric for n in part.flatten().notes]
+    assert lyrics == [None, None]
+    assert any("lyrics_words" in r.getMessage() for r in caplog.records)
+
+
+def test_vocal_lyrics_mismatch(caplog):
+    gen = VocalGenerator()
+    midivocal_data = [
+        {"offset": 0.0, "pitch": "C4", "length": 1.0, "velocity": 80},
+        {"offset": 1.0, "pitch": "D4", "length": 1.0, "velocity": 80},
+    ]
+    with caplog.at_level(logging.WARNING):
+        part = gen.compose(
+            midivocal_data,
+            processed_chord_stream=[],
+            humanize_opt=False,
+            lyrics_words=["あ", "い", "う"],
+        )
+    lyrics = [n.lyric for n in part.flatten().notes]
+    assert lyrics == ["あ", "い"]
+    assert any("syllables" in r.getMessage() for r in caplog.records)
 


### PR DESCRIPTION
## Summary
- warn about empty lyric data in `VocalGenerator`
- log mismatched note/lyric counts when inserting lyrics
- add unit tests covering empty and mismatched lyric cases

## Testing
- `pytest tests/test_vocal_lyrics.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c9089fd1483289b63acea55bd3dd6