### PR TITLE
Implement attention_mask and test updates for Sax

### DIFF
--- a/tests/test_sax_tokenizer.py
+++ b/tests/test_sax_tokenizer.py
@@ -5,7 +5,8 @@ def test_round_trip_with_artic() -> None:
     tok = SaxTokenizer()
     events = [
         {"bar": 0, "note": 60, "artic": "slide_up"},
-        {"bar": 1, "note": 62, "artic": "alt_hit"},
+        {"bar": 1, "note": 61, "artic": "slide_down"},
+        {"bar": 2, "note": 62, "artic": "alt_hit"},
     ]
     ids = tok.encode(events)
     decoded = tok.decode(ids)

--- a/train_sax_lora.py
+++ b/train_sax_lora.py
@@ -97,6 +97,7 @@ def main() -> None:
         max_steps=args.steps,
         logging_steps=10,
         save_steps=50,
+        remove_unused_columns=False,
     )
     trainer = Trainer(
         model=model,

--- a/transformer/sax_transformer.py
+++ b/transformer/sax_transformer.py
@@ -32,10 +32,20 @@ class SaxTransformer(nn.Module if torch is not None else object):
         lora_cfg = LoraConfig(task_type=TaskType.CAUSAL_LM, r=rank, lora_alpha=16, target_modules=["c_attn"], inference_mode=False)
         self.model = get_peft_model(base, lora_cfg)
 
-    def forward(self, input_ids: torch.Tensor, past_key_values: tuple[tuple[torch.Tensor, ...], ...] | None = None) -> torch.Tensor:
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values: tuple[tuple[torch.Tensor, ...], ...] | None = None,
+    ) -> torch.Tensor:
         if torch is None:
             raise RuntimeError("torch not available")
-        outputs = self.model(input_ids=input_ids, past_key_values=past_key_values, use_cache=True)
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=True,
+        )
         return outputs.logits
 
 


### PR DESCRIPTION
## Summary
- pass attention masks through LoRA SaxTransformer
- keep unused columns so Trainer forwards masks
- verify slide-down token in tokenizer tests

## Testing
- `pytest tests/test_sax_tokenizer.py tests/test_sax_transformer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d06ef20288328b2319288bd6699d9