### PR TITLE
Enhance vocal synthesis logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,17 @@ Lyrics can be supplied to `VocalGenerator.compose` via the `lyrics_words` option
 python scripts/synthesize_vocal.py --mid vocal.mid --phonemes phon.json --out audio/
 ```
 
+## TTS ONNX Integration
+You can run the synthesizer with an ONNX model instead of the default TTS backend.
+Enable verbose logging with `--log-level`:
+
+```bash
+python scripts/synthesize_vocal.py --mid vocal.mid --phonemes phon.json \
+    --out audio/ --onnx-model model.onnx --log-level DEBUG
+```
+
+The script exits with code `0` on success and `1` on error.
+
 Specify a custom phoneme mapping when sampling vocals:
 
 ```bash

--- a/docs/vocal_generator.md
+++ b/docs/vocal_generator.md
@@ -29,6 +29,16 @@ Invoke it as follows:
 python scripts/synthesize_vocal.py --mid vocal.mid --phonemes phonemes.json --out audio/
 ```
 
+## TTS ONNX Integration
+To run synthesis through an ONNX model pass the `--onnx-model` option and specify a log level:
+
+```bash
+python scripts/synthesize_vocal.py --mid vocal.mid --phonemes phonemes.json \
+    --out audio/ --onnx-model model.onnx --log-level DEBUG
+```
+
+Exit status is `0` when the WAV is created successfully and `1` if synthesis fails.
+
 To use a custom phoneme mapping when sampling from the CLI:
 
 ```bash

--- a/scripts/synthesize_vocal.py
+++ b/scripts/synthesize_vocal.py
@@ -1,21 +1,44 @@
 import argparse
 import json
+import logging
+import sys
 from pathlib import Path
-
-from tts_model import synthesize
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="Synthesize vocals with phoneme sequence")
+    parser = argparse.ArgumentParser(
+        description="Synthesize vocals with phoneme sequence"
+    )
     parser.add_argument("--mid", type=Path, required=True)
     parser.add_argument("--phonemes", type=Path, required=True)
     parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--onnx-model", type=Path)
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
     args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level))
 
     with args.phonemes.open("r", encoding="utf-8") as f:
         phonemes = json.load(f)
 
-    audio = synthesize(args.mid, phonemes)
+    try:
+        logging.info("Starting synthesis for %s", args.mid)
+        if args.onnx_model:
+            from generator.vocal_generator import synthesize_with_onnx
+
+            audio = synthesize_with_onnx(args.onnx_model, args.mid, phonemes)
+        else:
+            from tts_model import synthesize  # type: ignore
+
+            audio = synthesize(args.mid, phonemes)
+        logging.info("Finished synthesis")
+    except (ImportError, RuntimeError) as exc:  # pragma: no cover - runtime path
+        logging.error("TTS synthesis failed: %s", exc, exc_info=True)
+        sys.exit(1)
     args.out.mkdir(parents=True, exist_ok=True)
     out_file = args.out / f"{args.mid.stem}.wav"
     out_file.write_bytes(audio)

--- a/tests/test_onnx_wrapper.py
+++ b/tests/test_onnx_wrapper.py
@@ -1,0 +1,51 @@
+import importlib
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+from generator import vocal_generator
+
+
+def test_synthesize_with_onnx_success(tmp_path, monkeypatch, caplog):
+    model = tmp_path / "model.onnx"
+    model.write_bytes(b"stub")
+    midi = tmp_path / "test.mid"
+    midi.write_bytes(b"MThd")
+
+    calls = {}
+
+    class DummySession:
+        def __init__(self, path):
+            calls["path"] = Path(path)
+        def run(self, outputs, feeds):
+            calls["feeds"] = feeds
+            return [b"audio"]
+
+    monkeypatch.setitem(sys.modules, "onnxruntime", types.SimpleNamespace(InferenceSession=DummySession))
+    importlib.reload(vocal_generator)
+
+    with caplog.at_level("INFO"):
+        result = vocal_generator.synthesize_with_onnx(model, midi, ["a"])
+    assert result == b"audio"
+    assert calls["path"] == model
+    assert "input" in calls["feeds"]
+    assert "Starting ONNX synthesis" in caplog.text
+    assert "Finished ONNX synthesis" in caplog.text
+
+
+def test_synthesize_with_onnx_import_error(tmp_path, monkeypatch, caplog):
+    if "onnxruntime" in sys.modules:
+        del sys.modules["onnxruntime"]
+    import builtins
+    orig_import = builtins.__import__
+    def fake_import(name, *args, **kwargs):
+        if name == "onnxruntime":
+            raise ImportError("missing")
+        return orig_import(name, *args, **kwargs)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with caplog.at_level("ERROR"):
+        result = vocal_generator.synthesize_with_onnx(tmp_path/"m.onnx", tmp_path/"m.mid", ["a"])
+    assert result == b""
+    assert "Failed to import onnxruntime" in caplog.text

--- a/tests/test_synthesize_vocal_cli.py
+++ b/tests/test_synthesize_vocal_cli.py
@@ -1,0 +1,141 @@
+import json
+import builtins
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+def _setup_files(tmp_path: Path):
+    midi = tmp_path / "test.mid"
+    midi.write_bytes(b"MThd\x00\x00\x00\x06\x00\x01\x00\x01\x00`MTrk\x00\x00\x00\x04\x00\xFF/\x00")
+    phon = tmp_path / "phon.json"
+    phon.write_text(json.dumps(["a"]))
+    return midi, phon
+
+
+def test_cli_success(tmp_path, monkeypatch):
+    midi, phon = _setup_files(tmp_path)
+    out_dir = tmp_path / "out"
+    model = tmp_path / "model.onnx"
+
+    calls = {}
+
+    def fake_onnx(model_path, midi_path, phonemes):
+        calls["args"] = (Path(model_path), Path(midi_path), phonemes)
+        return b"OK"
+
+    from generator import vocal_generator
+
+    monkeypatch.setattr(vocal_generator, "synthesize_with_onnx", fake_onnx)
+    from scripts import synthesize_vocal
+    importlib.reload(synthesize_vocal)
+
+    out = synthesize_vocal.main([
+        "--mid",
+        str(midi),
+        "--phonemes",
+        str(phon),
+        "--out",
+        str(out_dir),
+        "--onnx-model",
+        str(model),
+    ])
+
+    out_file = out_dir / "test.wav"
+    assert out_file.read_bytes() == b"OK"
+    assert out == out_file
+    assert calls["args"] == (model, midi, ["a"])
+
+
+def test_cli_error(monkeypatch, tmp_path):
+    midi, phon = _setup_files(tmp_path)
+    out_dir = tmp_path / "out"
+    model = tmp_path / "model.onnx"
+
+    def fake_onnx(*a, **k):
+        raise RuntimeError("boom")
+
+    from generator import vocal_generator
+
+    monkeypatch.setattr(vocal_generator, "synthesize_with_onnx", fake_onnx)
+    from scripts import synthesize_vocal
+    importlib.reload(synthesize_vocal)
+
+    with pytest.raises(SystemExit) as exc:
+        synthesize_vocal.main([
+            "--mid",
+            str(midi),
+            "--phonemes",
+            str(phon),
+            "--out",
+            str(out_dir),
+            "--onnx-model",
+            str(model),
+        ])
+    assert exc.value.code == 1
+
+
+def test_cli_import_error(monkeypatch, tmp_path):
+    midi, phon = _setup_files(tmp_path)
+    out_dir = tmp_path / "out"
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "tts_model":
+            raise ImportError("missing")
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    from scripts import synthesize_vocal
+    importlib.reload(synthesize_vocal)
+
+    with pytest.raises(SystemExit) as exc:
+        synthesize_vocal.main([
+            "--mid",
+            str(midi),
+            "--phonemes",
+            str(phon),
+            "--out",
+            str(out_dir),
+        ])
+    assert exc.value.code == 1
+
+
+def test_cli_default_tts(tmp_path, monkeypatch):
+    # 準備
+    midi = tmp_path / "m.mid"
+    midi.write_bytes(b"MThd")
+    phon = tmp_path / "p.json"
+    phon.write_text(json.dumps(["a"]))
+    out = tmp_path / "out"
+    calls = {}
+
+    # tts_model.synthesize をモック
+    def fake_synth(m, p):
+        calls['args'] = (Path(m), p)
+        return b"TTS"
+
+    import sys, types
+    monkeypatch.setitem(sys.modules, 'tts_model', types.SimpleNamespace(synthesize=fake_synth))
+
+    # 再ロードして実行
+    from scripts import synthesize_vocal
+    import importlib
+    importlib.reload(synthesize_vocal)
+
+    result = synthesize_vocal.main([
+        "--mid",
+        str(midi),
+        "--phonemes",
+        str(phon),
+        "--out",
+        str(out),
+    ])
+
+    # アサート
+    out_file = out / "m.wav"
+    assert out_file.read_bytes() == b"TTS"
+    assert calls['args'] == (midi, ["a"])
+    assert result == out_file


### PR DESCRIPTION
## Summary
- add start/end logging and graceful failures in `synthesize_with_onnx`
- log TTS synth begin/end inside `VocalGenerator.synthesize_with_tts`
- log synthesis steps in `synthesize_vocal.py`
- verify log messages in updated unit tests
- document ONNX usage and exit codes
- test default CLI behavior without `--onnx-model`

## Testing
- `pytest tests/test_synthesize_vocal_cli.py::test_cli_default_tts -q` *(fails: Missing packages)*
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_686ce7ecdbc08328ab5d39f2968f2747