### PR TITLE
Add vibrato engine controls in CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           - os: ubuntu-latest
             variant: PG_DELTA
           - os: ubuntu-latest
+            variant: PG_DELTA_VOCAL
+          - os: ubuntu-latest
             variant: PIANO_ML_HEAVY
           - os: ubuntu-latest
             variant: PG_EPSILON
@@ -41,7 +43,7 @@ jobs:
           path: ~/.cache/pip/wheels/**/cyext*
           key: ${{ runner.os }}-cyext-${{ hashFiles('cyext/**.pyx') }}
       - name: Install dependencies
-        if: matrix.variant == 'PURE_PY' || matrix.variant == 'PG_BETA' || matrix.variant == 'PG_DELTA' || matrix.variant == 'PG_EPSILON'
+        if: matrix.variant == 'PURE_PY' || matrix.variant == 'PG_BETA' || matrix.variant == 'PG_DELTA' || matrix.variant == 'PG_DELTA_VOCAL' || matrix.variant == 'PG_EPSILON'
         run: pip install -r requirements.txt
       - name: Install dependencies (ML)
         if: matrix.variant == 'PIANO_ML'
@@ -52,7 +54,7 @@ jobs:
       - name: Install test tools
         run: pip install -e .[test] -r requirements-test.txt
       - name: Set ML env (pure)
-        if: matrix.variant == 'PURE_PY' || matrix.variant == 'PG_BETA' || matrix.variant == 'PG_DELTA' || matrix.variant == 'PG_EPSILON'
+        if: matrix.variant == 'PURE_PY' || matrix.variant == 'PG_BETA' || matrix.variant == 'PG_DELTA' || matrix.variant == 'PG_DELTA_VOCAL' || matrix.variant == 'PG_EPSILON'
         run: echo "ENABLE_ML_TESTS=false" >> $GITHUB_ENV
       - name: Set ML env (ml)
         if: matrix.variant == 'PIANO_ML' || matrix.variant == 'PIANO_ML_HEAVY'
@@ -110,11 +112,13 @@ jobs:
                 tests/test_piano_ml_stub.py
           elif [ "${{ matrix.variant }}" = "PG_DELTA" ]; then
               pytest -q tests/test_articulation_cc.py tests/test_loudness_norm.py tests/test_tone_presets.py
+          elif [ "${{ matrix.variant }}" = "PG_DELTA_VOCAL" ]; then
+              pytest -q tests/test_vibrato_engine.py tests/test_vocal_articulation_integration.py
           elif [ "$ENABLE_ML_TESTS" = "true" ]; then
               # 通常 ML ジョブ ― 全テスト実行
               pytest -q
           else
-              # PURE_PY / PG_BETA / PG_DELTA / PG_EPSILON ― ML マークを除外
+              # PURE_PY / PG_BETA / PG_DELTA / PG_DELTA_VOCAL / PG_EPSILON ― ML マークを除外
               pytest -q -m "not ml"
           fi
       - name: MIDI Regression Tests

--- a/README.md
+++ b/README.md
@@ -849,11 +849,20 @@ profiles (`grand_clean`, `upright_mellow`, `ep_phase`). Pass
 `--no-enable-articulation` to disable glissando and trill tags. Generated notes
 are normalised with `normalize_velocities()` so that loudness stays consistent.
 See [docs/piano_delta.md](docs/piano_delta.md) for details.
+Vocal vibrato may be tweaked via `--vibrato-depth` and `--vibrato-rate`:
+
+```bash
+modcompose sample model.pt --backend vocal --vibrato-depth 0.7 --vibrato-rate 6
+```
 Add to `main_cfg.yml` to avoid long CLI flags:
 ```yaml
 part_defaults:
   piano:
     tone_preset: grand_clean
+    enable_articulation: true
+  vocal:
+    vibrato_depth: 0.5
+    vibrato_rate: 5.0
     enable_articulation: true
 ```
 

--- a/config/main_cfg_example.yml
+++ b/config/main_cfg_example.yml
@@ -2,3 +2,7 @@ part_defaults:
   piano:
     tone_preset: grand_clean
     enable_articulation: true
+  vocal:
+    vibrato_depth: 0.5
+    vibrato_rate: 5.0
+    enable_articulation: true

--- a/docs/vocal_generator.md
+++ b/docs/vocal_generator.md
@@ -13,12 +13,24 @@ and rate in cycles per quarter note.
 The events are attached to each note in
 `_apply_vibrato_to_part`.
 
+
 ```python
 from utilities.vibrato_engine import generate_vibrato
 
 # example: 1 qL note with 0.5 semitone depth at 5 Hz
 events = generate_vibrato(1.0, 0.5, 5.0)
 ```
+
+## Expression & Vibrato
+
+`VocalGenerator` exposes articulation parameters so that vibrato and special
+markers can be toggled from the CLI or config file.  Pass
+`--vibrato-depth` and `--vibrato-rate` on the command line, or set them under
+`part_defaults.vocal` in `main_cfg.yml`.
+
+Use `--no-enable-articulation` to disable vibrato, glissando and trill events.
+The values are passed directly to `generate_vibrato`,
+`generate_gliss`, and `generate_trill`.
 
 ## TTS Integration
 `scripts/synthesize_vocal.py` reads a MIDI file and a JSON list of
@@ -43,6 +55,13 @@ To use a custom phoneme mapping when sampling from the CLI:
 
 ```bash
 modcompose sample --backend vocal --phoneme-dict custom_dict.json
+```
+
+Adjust vibrato behaviour with `--vibrato-depth` and `--vibrato-rate`:
+
+```bash
+modcompose sample model.pt --backend vocal \
+    --vibrato-depth 0.6 --vibrato-rate 6
 ```
 
 The output file is written under the directory specified by `--out`.

--- a/modular_composer/cli.py
+++ b/modular_composer/cli.py
@@ -548,6 +548,18 @@ def _cmd_sample(args: list[str]) -> None:
         help="Select piano/bass tone preset",
     )
     ap.add_argument(
+        "--vibrato-depth",
+        type=float,
+        default=0.5,
+        help="Vocal vibrato depth in semitones",
+    )
+    ap.add_argument(
+        "--vibrato-rate",
+        type=float,
+        default=5.0,
+        help="Vocal vibrato rate in Hz",
+    )
+    ap.add_argument(
         "--enable-articulation",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -653,7 +665,12 @@ def _cmd_sample(args: list[str]) -> None:
     elif ns.backend == "vocal":
         from generator.vocal_generator import VocalGenerator
 
-        gen = VocalGenerator(phoneme_dict_path=ns.phoneme_dict)
+        gen = VocalGenerator(
+            phoneme_dict_path=ns.phoneme_dict,
+            vibrato_depth=ns.vibrato_depth,
+            vibrato_rate=ns.vibrato_rate,
+            enable_articulation=ns.enable_articulation,
+        )
         part = gen.compose(
             [
                 {

--- a/tests/test_vibrato_engine.py
+++ b/tests/test_vibrato_engine.py
@@ -1,9 +1,30 @@
-from utilities.vibrato_engine import generate_vibrato
+import random
+from utilities.vibrato_engine import generate_vibrato, generate_gliss, generate_trill
 
 
-def test_generate_vibrato_waveform():
-    events = generate_vibrato(0.2, 0.5, 5.0, step=0.05)
-    bends = [e["value"] for e in events if e["type"] == "pitchwheel"]
-    assert bends == [0, 2048, 0, -2048, 0]
-    touches = [e["value"] for e in events if e["type"] == "aftertouch"]
-    assert len(touches) == len(bends)
+def test_generate_vibrato_alternating() -> None:
+    events = generate_vibrato(0.25, 1.0, 5.0)
+    assert len(events) == 5
+    types = [e[0] for e in events]
+    assert types == ["pitch_wheel", "aftertouch", "pitch_wheel", "aftertouch", "pitch_wheel"]
+    values = [e[2] for e in events]
+    assert all(-8192 <= v <= 8192 for v in values)
+
+
+def test_generate_gliss_linear() -> None:
+    events = generate_gliss(60, 64, 0.5)
+    assert len(events) == 5
+    pitches = [p for p, _ in events]
+    assert pitches[0] == 60 and pitches[-1] == 64
+    assert all(pitches[i] <= pitches[i + 1] for i in range(len(pitches) - 1))
+
+
+def test_generate_trill_velocity_range() -> None:
+    random.seed(0)
+    events = generate_trill(60, 0.5, rate=8.0)
+    assert len(events) == 5
+    pitches = [p for p, _, _ in events]
+    for i in range(len(pitches) - 1):
+        assert pitches[i] != pitches[i + 1]
+    velocities = [v for _, _, v in events]
+    assert all(59 <= v <= 69 for v in velocities)

--- a/tests/test_vocal_articulation_integration.py
+++ b/tests/test_vocal_articulation_integration.py
@@ -1,0 +1,21 @@
+import logging
+from generator.vocal_generator import VocalGenerator
+
+
+def _make_data():
+    return [
+        {"offset": 0.0, "pitch": "C4", "length": 1.0, "velocity": 90},
+        {"offset": 1.0, "pitch": "D4", "length": 1.0, "velocity": 90},
+    ]
+
+
+def test_vibrato_engine_integration():
+    gen = VocalGenerator()
+    part = gen.compose(
+        _make_data(), processed_chord_stream=[], humanize_opt=False, lyrics_words=["a", "b"]
+    )
+    cc74 = [e for e in getattr(part, "extra_cc", []) if e.get("cc") == 74]
+    assert cc74, "aftertouch events missing"
+    bends = getattr(part, "pitch_bends", [])
+    assert bends and all("pitch" in b for b in bends)
+

--- a/utilities/vibrato_engine.py
+++ b/utilities/vibrato_engine.py
@@ -1,9 +1,19 @@
+"""Utility functions to generate basic MIDI expression curves."""
+
+from __future__ import annotations
+
 import math
-from typing import List, Dict
+import random
+from typing import List, Tuple, Literal
 
 
-def generate_vibrato(duration_qL: float, depth: float, rate: float, *, step: float = 0.05) -> List[Dict[str, int | float]]:
-    """Return vibrato pitchwheel/aftertouch events.
+Event = Tuple[Literal["pitch_wheel", "aftertouch"], float, int]
+
+
+def generate_vibrato(
+    duration_qL: float, depth: float, rate: float, step_qL: float = 0.0625
+) -> List[Event]:
+    """Return vibrato pitch bend and aftertouch events.
 
     Parameters
     ----------
@@ -13,22 +23,68 @@ def generate_vibrato(duration_qL: float, depth: float, rate: float, *, step: flo
         Depth in semitones. Converted to pitch-wheel value assuming +/-2 range.
     rate:
         Oscillation rate in cycles per quarter note.
-    step:
-        Step size for waveform in quarterLength. Defaults to 0.05.
+    step_qL:
+        Spacing for the waveform in quarterLength. Defaults to one 64th note
+        (0.0625).
     """
-    events: List[Dict[str, int | float]] = []
-    if duration_qL <= 0 or step <= 0:
+    events: List[Event] = []
+    if duration_qL <= 0 or step_qL <= 0:
         return events
     semitone_range = 2.0
     amplitude = depth / semitone_range * 8192
     cc_val = max(0, min(127, int(round(64 + depth * 63))))
     t = 0.0
+    index = 0
     while t <= duration_qL + 1e-9:
-        bend = int(round(amplitude * math.sin(2 * math.pi * rate * t)))
-        events.append({"time": round(t, 6), "type": "pitchwheel", "value": bend})
-        events.append({"time": round(t, 6), "type": "aftertouch", "value": cc_val})
+        if index % 2 == 0:
+            bend = int(round(amplitude * math.sin(2 * math.pi * rate * t)))
+            events.append(("pitch_wheel", round(t, 6), bend))
+        else:
+            events.append(("aftertouch", round(t, 6), cc_val))
+        t += step_qL
+        index += 1
+    return events
+
+
+def generate_gliss(
+    start_pitch: int, end_pitch: int, duration_qL: float
+) -> List[Tuple[int, float]]:
+    """Return pitch values for a glissando linearly spaced every 32nd note."""
+
+    step = 0.125
+    if duration_qL <= 0 or start_pitch == end_pitch:
+        return [(start_pitch, 0.0)]
+
+    count = max(1, int(round(duration_qL / step)))
+    step_pitch = (end_pitch - start_pitch) / float(count)
+    events: List[Tuple[int, float]] = []
+    for i in range(count + 1):
+        t = min(duration_qL, i * step)
+        p = int(round(start_pitch + step_pitch * i))
+        events.append((p, t))
+    return events
+
+
+def generate_trill(
+    pitch: int, duration_qL: float, rate: float = 10.0
+) -> List[Tuple[int, float, int]]:
+    """Return a sequence of trilled notes as (pitch, time, velocity)."""
+
+    if duration_qL <= 0 or rate <= 0:
+        return []
+
+    step = 1.0 / rate
+    rng = random.Random(0)
+    events: List[Tuple[int, float, int]] = []
+    t = 0.0
+    use_upper = False
+    while t <= duration_qL + 1e-9:
+        p = pitch + (1 if use_upper else 0)
+        vel = max(1, min(127, 64 + rng.randint(-5, 5)))
+        events.append((p, round(t, 6), vel))
+        use_upper = not use_upper
         t += step
     return events
 
 
-__all__ = ["generate_vibrato"]
+__all__ = ["generate_vibrato", "generate_gliss", "generate_trill"]


### PR DESCRIPTION
## Summary
- expose vibrato settings on `modcompose sample`
- respect articulation flags in `VocalGenerator`
- document vibrato options and update example config
- run vibrato integration tests in PG_DELTA_VOCAL CI job

## Testing
- `pytest tests/test_vibrato_engine.py tests/test_vocal_articulation_integration.py -q`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_686d09cc4d188328ad2a66b41f778a9c