### PR TITLE
Bug fixes and seed init

### DIFF
--- a/generator/sax_generator.py
+++ b/generator/sax_generator.py
@@ -84,6 +84,14 @@ class SaxGenerator(MelodyGenerator):
         for k, v in DEFAULT_PHRASE_PATTERNS.items():
             rh_lib.setdefault(k, v)
 
+        if seed is not None:
+            random.seed(seed)
+            try:
+                import numpy as _np  # type: ignore
+                _np.random.seed(seed)
+            except Exception:
+                pass
+
         if "rng" not in kwargs:
             kwargs["rng"] = random.Random(seed)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "setuptools", "wheel", "build"]
 build-backend = "hatchling.build"
 
 [project]

--- a/utilities/velocity_curve.py
+++ b/utilities/velocity_curve.py
@@ -47,7 +47,9 @@ def _interpolate_7pt_cached(curve_tuple, mode: str) -> list[float]:
             cs = CubicSpline(x, curve7, bc_type="natural")
             x_new = np.linspace(0.0, 1.0, 128)
             y_new = cs(x_new)
-            return [float(v) for v in y_new]
+            result = [float(v) for v in y_new]
+            result[-1] = float(curve7[-1])
+            return result
         except Exception:
             pass
 
@@ -55,7 +57,9 @@ def _interpolate_7pt_cached(curve_tuple, mode: str) -> list[float]:
         x = np.array(x_points)
         x_new = np.linspace(0.0, 1.0, 128)
         y_new = np.interp(x_new, x, curve7)
-        return [float(v) for v in y_new]
+        result = [float(v) for v in y_new]
+        result[-1] = float(curve7[-1])
+        return result
 
     def lin_interp(x0, y0, x1, y1, x):
         return y0 + (y1 - y0) * (x - x0) / (x1 - x0)
@@ -77,6 +81,8 @@ def _interpolate_7pt_cached(curve_tuple, mode: str) -> list[float]:
                 break
     if len(result) < 128:
         result.extend([float(curve7[-1])] * (128 - len(result)))
+    if result:
+        result[-1] = float(curve7[-1])
     return [float(v) for v in result]
 
 


### PR DESCRIPTION
## Summary
- handle small vowels and dakuten when splitting vocal syllables
- ensure fallback lyrics assignment fills the first N notes
- seed NumPy RNG in `SaxGenerator`
- enforce velocity curve interpolation end point
- include build module in `pyproject.toml`

## Testing
- `pytest tests/test_vocal_lyrics.py::test_vocal_lyrics_mismatch -q`

------
https://chatgpt.com/codex/tasks/task_e_686d48de22f883288462a1e14ec985d5