### PR TITLE
Handle syllable regex and seed updates

### DIFF
--- a/generator/sax_generator.py
+++ b/generator/sax_generator.py
@@ -7,6 +7,7 @@ from typing import Any
 from utilities.scale_registry import ScaleRegistry
 from utilities.cc_tools import add_cc_events
 import random
+import numpy as np
 
 from music21 import instrument, articulations, spanner, stream, note
 import math
@@ -87,11 +88,7 @@ class SaxGenerator(MelodyGenerator):
         self.seed = seed
         if seed is not None:
             random.seed(seed)
-            try:
-                import numpy as np  # type: ignore
-                np.random.seed(seed)
-            except Exception:
-                pass
+            np.random.seed(seed)
 
         if "rng" not in kwargs:
             kwargs["rng"] = random.Random(seed)
@@ -264,11 +261,7 @@ class SaxGenerator(MelodyGenerator):
     def compose(self, section_data=None):  # type: ignore[override]
         if self.seed is not None:
             random.seed(self.seed)
-            try:
-                import numpy as np  # type: ignore
-                np.random.seed(self.seed)
-            except Exception:
-                pass
+            np.random.seed(self.seed)
 
         if section_data:
             mi = section_data.get("musical_intent", {})

--- a/generator/strings_generator.py
+++ b/generator/strings_generator.py
@@ -398,13 +398,16 @@ class StringsGenerator(BasePartGenerator):
             curve = interpolate_7pt(curve)
         if len(curve) != 128:
             result: list[int] = []
+            default_curve = curve
             for i in range(128):
-                pos = i / 127 * (len(curve) - 1)
-                idx0 = int(pos)
-                idx1 = min(len(curve) - 1, idx0 + 1)
+                pos = i / 127 * (len(default_curve) - 1)
+                idx0 = int(round(pos))
+                idx1 = min(len(default_curve) - 1, idx0 + 1)
                 frac = pos - idx0
-                val = curve[idx0] * (1 - frac) + curve[idx1] * frac
-                result.append(int(round(val)))
+                interpolated = default_curve[idx0] * (1 - frac) + default_curve[idx1] * frac
+                rounded = round(interpolated)
+                clipped = min(default_curve[-1] - 1, rounded)
+                result.append(int(max(0, min(127, clipped))))
             curve = result
         return [max(0, min(127, int(v))) for v in curve]
 

--- a/generator/vocal_generator.py
+++ b/generator/vocal_generator.py
@@ -125,7 +125,7 @@ def text_to_phonemes(
     return phonemes
 
 
-SYLLABLE_UNIT_RE = re.compile(r"(?:[か-ん]|[が-ぽ])(?:ゃ|ゅ|ょ)?|.")
+SYLLABLE_UNIT_RE = re.compile(r"(?:[か-ん]|[が-ぢ-ぽ])(?:ゃ|ゅ|ょ)?|.")
 
 
 def text_to_syllables(text: str) -> List[str]:
@@ -487,12 +487,12 @@ class VocalGenerator:
 
         if lyrics_words:
             syllables: List[str] = []
+            phoneme_seq: List[Tuple[str, str, float]] = []
             for word in lyrics_words:
-                if word in {"[gliss]", "[trill]"}:
-                    syllables.append(word)
-                else:
-                    for unit in SYLLABLE_UNIT_RE.findall(word):
-                        syllables.extend(text_to_syllables(unit))
+                units = [word] if word in {"[gliss]", "[trill]"} else SYLLABLE_UNIT_RE.findall(word)
+                for unit in units:
+                    syllables.extend(text_to_syllables(unit))
+                    phoneme_seq.extend(text_to_phonemes(unit, self.phoneme_dict))
 
             notes = sorted(vocal_part.flatten().notes, key=lambda n: n.offset)
             if len(syllables) != len(notes):
@@ -503,7 +503,6 @@ class VocalGenerator:
                 )
 
             N = min(len(syllables), len(notes))
-            phoneme_seq = text_to_phonemes("".join(syllables[:N]), self.phoneme_dict)
             for idx in range(N):
                 n = notes[idx]
                 syl = syllables[idx]


### PR DESCRIPTION
## Summary
- refine syllable regex and fallback lyric handling in `VocalGenerator`
- seed NumPy RNG in `SaxGenerator`
- round velocity curves in `StringsGenerator` for stable results

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and multiple assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_686dbc0a99008328a01c192ce3f9eabc