### PR TITLE
Improve Sax CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       MODC_BUILD_PLUGIN: OFF
     steps:
@@ -15,14 +18,30 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
+        shell: bash
         run: |
           pip install -r requirements.txt
           pip install -e .[test]
+          pip install mkdocs mkdocs-material mkdocstrings[python]
+      - name: Build SaxPlugin
+        shell: bash
+        run: |
+          pip install pybind11 cmake ninja
+          cmake -S plugins/sax_companion -B sax_build -DMODC_BUILD_PLUGIN=ON
+          cmake --build sax_build --config Release
+      - name: Verify docs
+        shell: bash
+        run: mkdocs build --strict
       - name: Run tests
+        id: run_tests
+        shell: bash
         run: make test
       - name: Generate demo MIDI
+        if: ${{ always() }}
+        shell: bash
         run: make demo-sax
       - uses: actions/upload-artifact@v4
+        if: ${{ steps.run_tests.outcome == 'failure' }}
         with:
-          name: demo-mid
+          name: demo-mid-${{ matrix.os }}
           path: demos/*.mid

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ demo:
 	python tools/generate_demo_midis.py -m config/main_cfg.yml
 
 demo-sax:
-	python tools/generate_demo_midis.py -m config/main_cfg.yml --sections sax_solo
+	python tools/generate_demo_midis.py -m config/sax_demo.yml --sections "Sax Solo"
 
 test:
 	pytest tests

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - Humanizer Reference: humanizer.md
   - Live Tips: live_tips.md
   - Vocal Generator: vocal_generator.md
+  - Sax Generator: sax_generator.md
   - API Reference:
       - modular_composer: api/modular_composer.md
 plugins:


### PR DESCRIPTION
## Summary
- build SaxPlugin with cmake
- check docs using mkdocs
- run tests and demo-sax on Linux, macOS and Windows
- upload demo MIDI when tests fail
- fix demo-sax target to use `config/sax_demo.yml`
- add Sax Generator page to mkdocs navigation

## Testing
- `bash setup.sh` *(installs dependencies)*
- `pytest -q` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686da5ff1fa0832882ae215b006394b3