### PR TITLE
Fix sax_demo config keys

### DIFF
--- a/config/sax_demo.yml
+++ b/config/sax_demo.yml
@@ -1,4 +1,16 @@
 # Minimal configuration for a short sax demo
+global_settings:
+  time_signature: "4/4"
+  tempo_bpm: 96
+  key_tonic: "F"
+  key_mode: "major"
+
+paths:
+  chordmap_path: "../data/processed_chordmap_with_emotion.yaml"
+  rhythm_library_path: "../data/rhythm_library.yml"
+  arrangement_overrides_path: "../data/arrangement_overrides.json"
+  output_dir: "../midi_output"
+
 sections_to_generate:
   - "Sax Solo"
 


### PR DESCRIPTION
## Summary
- add `global_settings` with default time signature, tempo, and key
- add `paths` entries for chordmap and rhythm library

## Testing
- `make test` *(fails: 2 failed, 511 passed, 99 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686e1e21341883288538f936753cc45f