### PR TITLE
Fix ws_vocal_bridge handler path

### DIFF
--- a/realtime/ws_vocal_bridge.py
+++ b/realtime/ws_vocal_bridge.py
@@ -56,7 +56,12 @@ async def serve(model: WarmModel, host: str = "localhost", port: int = 8765):
         raise RuntimeError("websockets library required")
 
     async def handler(ws):
-        if getattr(ws, "path", "/") != "/vocal":
+        # ``path`` attribute was removed in websockets>=15.  Use
+        # ``ws.request.path`` when available and fall back to ``ws.path`` for
+        # older versions to keep backward compatibility.
+        req = getattr(ws, "request", None)
+        path = getattr(req, "path", getattr(ws, "path", "/"))
+        if path != "/vocal":
             await ws.close()
             return
         async for message in ws:


### PR DESCRIPTION
## Summary
- update path handling in `ws_vocal_bridge` for websockets>=15
- ensure connection remains open during tests

## Testing
- `pytest -q`
- `pytest tests/test_ws_vocal_bridge.py::test_ws_vocal_bridge -q`

------
https://chatgpt.com/codex/tasks/task_e_686e48c64d808328a4cc82969d7e2453