### PR TITLE
Add Sax Solo section to chordmap

### DIFF
--- a/data/chordmap.json
+++ b/data/chordmap.json
@@ -861,6 +861,68 @@
         "tempo_feel_adjust_bpm": 1.5,
         "humanize_profile": "emotional_arc"
       }
+    },
+    "Sax Solo": {
+      "order": 14,
+      "length_in_measures": 8,
+      "tonic": "F",
+      "mode": "mixolydian",
+      "musical_intent": {
+        "emotion": "soaring_passion",
+        "intensity": "high"
+      },
+      "part_settings": {
+        "piano_rh_style_keyword": "piano_solo_support_rh",
+        "piano_lh_style_keyword": "piano_simple_pedal_bass_lh",
+        "piano_velocity_rh": 70,
+        "piano_velocity_lh": 60,
+        "piano_apply_pedal": true,
+        "drum_style_key": "light_cymbal_swell"
+      },
+      "part_specific_hints": {
+        "lyrics_end_actual_beats_from_section_start": 16.0
+      },
+      "chord_progression": [
+        {
+          "label": "F13",
+          "duration_beats": 4
+        },
+        {
+          "label": "Bbmaj7",
+          "duration_beats": 4
+        },
+        {
+          "label": "F7",
+          "duration_beats": 4
+        },
+        {
+          "label": "Emaj7",
+          "duration_beats": 4
+        },
+        {
+          "label": "Bbmaj7/D",
+          "duration_beats": 4
+        },
+        {
+          "label": "Gm7",
+          "duration_beats": 4
+        },
+        {
+          "label": "C7",
+          "duration_beats": 4
+        },
+        {
+          "label": "Fmaj7",
+          "duration_beats": 4,
+          "nuance": "final_flourish"
+        }
+      ],
+      "adjusted_start_beat": 420.0,
+      "expression_details": {
+        "dynamics_profile": "f",
+        "base_articulation": "legato",
+        "tempo_feel_adjust_bpm": 0.0,
+        "humanize_profile": "expressive_solo"
+      }
     }
-  }
-}
+  }}

--- a/data/drum_patterns.yml
+++ b/data/drum_patterns.yml
@@ -234,7 +234,7 @@ drum_patterns:
         offset: 3.5
         duration: 1.0
       - instrument: crash
-        offset: 4.0
+        offset: 3.75
         duration: 1.0
 
   snare_roll_fill:
@@ -266,7 +266,7 @@ drum_patterns:
         offset: 3.875
         duration: 1.0
       - instrument: crash
-        offset: 4.0
+        offset: 3.75
         duration: 1.0
 
   cymbal_swell_fill:
@@ -280,7 +280,7 @@ drum_patterns:
         offset: 3.75
         duration: 1.0
       - instrument: crash
-        offset: 4.0
+      offset: 3.75
         duration: 1.0
 
   tom_run_short:
@@ -580,7 +580,7 @@ tom_triplet_fill:
     - instrument: tom3
       offset: 3.5
     - instrument: crash
-      offset: 4.0
+      offset: 3.75
 
 snare_roll_fill:
   description: "サビ前やブレイクで使えるスネアロール"
@@ -603,7 +603,7 @@ snare_roll_fill:
     - instrument: snare
       offset: 3.875
     - instrument: crash
-      offset: 4.0
+      offset: 3.75
 
 cymbal_swell_fill:
   description: "盛り上げ用のクラッシュ連打"
@@ -614,7 +614,7 @@ cymbal_swell_fill:
     - instrument: crash
       offset: 3.75
     - instrument: crash
-      offset: 4.0
+      offset: 3.75
 
 
 # --- ゴーストノート多用型 ---

--- a/data/rhythm_library.yml
+++ b/data/rhythm_library.yml
@@ -1047,7 +1047,7 @@ drum_patterns:
       - {offset: 3.25, duration: 0.25, instrument: tom2}
       - {offset: 3.50, duration: 0.25, instrument: tom3}
       - {offset: 3.75, duration: 0.25, instrument: tom2}
-      - {offset: 4.00, duration: 0.25, instrument: crash}
+      - {offset: 3.75, duration: 0.25, instrument: crash}
 
   fill_8th_crash:
     description: "Crash hits on 8ths"
@@ -1056,7 +1056,7 @@ drum_patterns:
     pattern:
       - {offset: 3.00, duration: 0.5, instrument: crash}
       - {offset: 3.50, duration: 0.5, instrument: crash}
-      - {offset: 4.00, duration: 0.5, instrument: crash}
+      - {offset: 3.75, duration: 0.5, instrument: crash}
 
   # --- 基本グルーヴパターン ---
   calm_backbeat:
@@ -1295,7 +1295,7 @@ drum_patterns:
         offset: 3.5
         duration: 1.0
       - instrument: crash
-        offset: 4.0
+        offset: 3.75
         duration: 1.0
   
   snare_roll_fill:
@@ -1327,7 +1327,7 @@ drum_patterns:
         offset: 3.875
         duration: 1.0
       - instrument: crash
-        offset: 4.0
+        offset: 3.75
         duration: 1.0
   
   cymbal_swell_fill:
@@ -1341,7 +1341,7 @@ drum_patterns:
         offset: 3.75
         duration: 1.0
       - instrument: crash
-        offset: 4.0
+        offset: 3.75
         duration: 1.0
 
   chorus_end_fill:
@@ -1362,7 +1362,7 @@ drum_patterns:
         velocity_factor: 1.1
         duration: 1.0
       - instrument: crash
-        offset: 4.0
+        offset: 3.75
         velocity_factor: 1.2
         duration: 1.0
   


### PR DESCRIPTION
## Summary
- add missing Sax Solo section to `chordmap.json`
- clamp drum pattern offsets to avoid step overflow

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed29687e083288ef09a918aba1812