### PR TITLE
Implement StringsGenerator Phase 5

### DIFF
--- a/.github/workflows/packaging-smoke.yml
+++ b/.github/workflows/packaging-smoke.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+      - name: Install system deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y fluidsynth libsoxr-dev
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip/wheels/**/cyext*
@@ -37,3 +40,4 @@ jobs:
       - run: python -m build --wheel
       - run: mkdocs build --strict
       - run: pytest tests/test_wheel_import.py tests/test_docs_build.py -q
+      - run: pytest -m "requires_audio" -q

--- a/docs/effect_presets.md
+++ b/docs/effect_presets.md
@@ -1,0 +1,41 @@
+# Effect Preset Format
+
+Effect presets map a name to an impulse response file and optional CC values.
+
+```yaml
+concert_hall:
+  ir_file: "irs/hall.wav"
+  cc:
+    91: 80
+    93: 20
+```
+
+Load presets with `EffectPresetLoader.load()` and retrieve them using `get()`.
+
+```python
+from utilities.effect_preset_loader import EffectPresetLoader
+EffectPresetLoader.load("data/strings_fx.yml")
+conf = EffectPresetLoader.get("concert_hall")
+```
+
+## Strings IR rendering
+
+Use ``modcompose ir-render`` to apply impulse responses to strings sections:
+
+```bash
+modcompose ir-render strings.mid irs/hall.wav --part strings -o rendered.wav
+```
+
+Example of a multi-band EQ preset in JSON format:
+
+```json
+{
+  "strings_eq": {
+    "ir_file": "irs/strings_eq.wav",
+    "cc": {
+      "11": 80
+    },
+    "eq": {"low": -3, "mid": 2, "high": 1}
+  }
+}
+```

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -92,3 +92,12 @@ part_params:
       start: 40
       end: 90
 ```
+
+### Strings IR レンダリング例
+
+```python
+from generator.strings_generator import StringsGenerator
+gen = StringsGenerator()
+parts = gen.compose(section_data={"section_name": "A", "q_length": 1.0})
+gen.export_audio(ir_name="hall", out_path="out/strings_A.wav")
+```

--- a/tests/test_effect_preset_loader.py
+++ b/tests/test_effect_preset_loader.py
@@ -1,0 +1,16 @@
+import logging
+from pathlib import Path
+from utilities.effect_preset_loader import EffectPresetLoader
+
+
+def test_reload(tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
+    cfg = tmp_path / "fx.yml"
+    cfg.write_text("hall:\n  ir_file: irs/hall.wav\n")
+    EffectPresetLoader.load(str(cfg))
+    assert EffectPresetLoader.get("hall")["ir_file"] == "irs/hall.wav"
+    cfg.write_text("hall:\n  ir_file: irs/room.wav\n")
+    EffectPresetLoader.reload()
+    assert EffectPresetLoader.get("hall")["ir_file"] == "irs/room.wav"
+    EffectPresetLoader.get("missing")
+    assert any("missing" in r.message for r in caplog.records)

--- a/tests/test_mix_profile.py
+++ b/tests/test_mix_profile.py
@@ -23,6 +23,7 @@ def test_export_mix_json(tmp_path):
     assert set(entry).issuperset({"extra_cc", "ir_file", "preset", "fx_cc"})
     assert entry["ir_file"] == str(tmp_path / "ir.wav")
     assert "fx_envelope" not in entry
+    assert "rendered_wav" not in entry
     times = [e["time"] for e in entry["fx_cc"]]
     assert times == sorted(times)
 
@@ -39,3 +40,20 @@ def test_export_mix_json_fx_env(tmp_path):
     export_mix_json(part, out)
     data = json.loads(out.read_text())
     assert data["x"]["fx_envelope"] == {"0": {"cc": 91}}
+
+
+def test_export_mix_json_strings_rendered(tmp_path):
+    part = stream.Part()
+    part.id = "violin_i"
+    from music21 import metadata
+    part.metadata = metadata.Metadata()
+    part.metadata.ir_file = tmp_path / "ir.wav"
+    part.metadata.rendered_wav = tmp_path / "out.wav"
+    (tmp_path / "ir.wav").write_text("dummy")
+    (tmp_path / "out.wav").write_text("dummy")
+    out = tmp_path / "mix3.json"
+    export_mix_json(part, out)
+    data = json.loads(out.read_text())
+    entry = data["violin_i"]
+    assert entry["ir_file"] == str(tmp_path / "ir.wav")
+    assert entry["rendered_wav"] == str(tmp_path / "out.wav")

--- a/tests/test_strings_audio_export.py
+++ b/tests/test_strings_audio_export.py
@@ -1,0 +1,54 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+import pytest
+from music21 import instrument
+from utilities.audio_env import has_fluidsynth
+
+pytestmark = pytest.mark.requires_audio
+sf = pytest.importorskip("soundfile")
+if not has_fluidsynth():
+    pytest.skip("fluidsynth missing", allow_module_level=True)
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("generator")
+pkg.__path__ = [str(ROOT / "generator")]
+sys.modules.setdefault("generator", pkg)
+
+spec = importlib.util.spec_from_file_location("generator.strings_generator", ROOT / "generator" / "strings_generator.py")
+strings_module = importlib.util.module_from_spec(spec)
+sys.modules["generator.strings_generator"] = strings_module
+spec.loader.exec_module(strings_module)
+StringsGenerator = strings_module.StringsGenerator
+
+
+def _gen():
+    return StringsGenerator(
+        global_settings={},
+        default_instrument=instrument.Violin(),
+        part_name="strings",
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+    )
+
+
+def test_export_audio(tmp_path):
+    gen = _gen()
+    sec = {
+        "section_name": "A",
+        "q_length": 1.0,
+        "humanized_duration_beats": 1.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+    }
+    gen.compose(section_data=sec)
+    ir = tmp_path / "ir.wav"
+    sf.write(ir, [1.0], 44100)
+    out = tmp_path / "out.wav"
+    result = gen.export_audio(ir_name=str(ir), out_path=out)
+    assert result.is_file()
+    data, _ = sf.read(result)
+    assert len(data) > 0

--- a/tests/test_strings_effects.py
+++ b/tests/test_strings_effects.py
@@ -1,0 +1,49 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from music21 import instrument
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("generator")
+pkg.__path__ = [str(ROOT / "generator")]
+sys.modules.setdefault("generator", pkg)
+
+spec = importlib.util.spec_from_file_location("generator.strings_generator", ROOT / "generator" / "strings_generator.py")
+strings_module = importlib.util.module_from_spec(spec)
+sys.modules["generator.strings_generator"] = strings_module
+spec.loader.exec_module(strings_module)
+StringsGenerator = strings_module.StringsGenerator
+EffectPresetLoader = strings_module.EffectPresetLoader
+
+
+def _gen():
+    return StringsGenerator(
+        global_settings={},
+        default_instrument=instrument.Violin(),
+        part_name="strings",
+        global_tempo=120,
+        global_time_signature="4/4",
+        global_key_signature_tonic="C",
+        global_key_signature_mode="major",
+    )
+
+
+def test_apply_effect_preset(tmp_path):
+    cfg = tmp_path / "fx.yml"
+    cfg.write_text("hall:\n  ir_file: irs/hall.wav\n  cc:\n    91: 80\n")
+    EffectPresetLoader.load(str(cfg))
+
+    gen = _gen()
+    sec = {
+        "section_name": "A",
+        "q_length": 1.0,
+        "humanized_duration_beats": 1.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+    }
+    parts = gen.compose(section_data=sec)
+    part = parts["violin_i"]
+    gen.apply_effect_preset(part, "hall")
+    assert getattr(part.metadata, "ir_file", None) == "irs/hall.wav"
+    assert any(e.get("cc") == 91 and e.get("val") == 80 for e in part.extra_cc)

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -197,6 +197,8 @@ except ModuleNotFoundError:
     ir_renderer = None  # type: ignore
 if importlib_util.find_spec("numpy") is not None:
     from .convolver import load_ir, convolve_ir, render_wav
+    from .audio_render import render_part_audio
+    from .effect_preset_loader import EffectPresetLoader
 else:
     import types, sys
 
@@ -216,6 +218,9 @@ else:
     load_ir = convolver_stub.load_ir
     convolve_ir = convolver_stub.convolve_ir
     render_wav = convolver_stub.render_wav
+    def render_part_audio(*_a: Any, **_k: Any) -> None:
+        _missing()
+    EffectPresetLoader = None  # type: ignore
 
 __all__ = [
     "MIN_NOTE_DURATION_QL",
@@ -266,6 +271,8 @@ __all__ = [
     "load_ir",
     "convolve_ir",
     "render_wav",
+    "render_part_audio",
+    "EffectPresetLoader",
 ]
 
 

--- a/utilities/audio_render.py
+++ b/utilities/audio_render.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Mapping
+
+from music21 import stream
+
+from .convolver import render_wav
+from .mix_profile import get_mix_chain
+
+
+def render_part_audio(
+    part: stream.Part | Mapping[str, stream.Part],
+    ir_name: str | None = None,
+    out_path: str | Path | None = None,
+    *,
+    sf2: str | None = None,
+    **mix_opts,
+) -> Path:
+    """Render ``part`` to ``out_path`` applying ``ir_name`` if given."""
+
+    if isinstance(part, dict):
+        parts = part
+    else:
+        parts = {getattr(part, "id", "part"): part}
+
+    score = stream.Score()
+    for p in parts.values():
+        score.insert(0, p)
+    tmp_mid = NamedTemporaryFile(suffix=".mid", delete=False)
+    score.write("midi", fp=tmp_mid.name)
+
+    if ir_name is None:
+        meta = next(iter(parts.values())).metadata
+        ir_file = getattr(meta, "ir_file", None) if meta is not None else None
+    else:
+        p = Path(ir_name)
+        if p.is_file():
+            ir_file = str(p)
+        else:
+            chain = get_mix_chain(ir_name, {}) or {}
+            ir_file = chain.get("ir_file")
+
+    if out_path is None:
+        out_path = "out.wav"
+
+    out = render_wav(tmp_mid.name, ir_file or "", str(out_path), sf2=sf2, parts=parts, **mix_opts)
+
+    Path(tmp_mid.name).unlink(missing_ok=True)
+    for p in parts.values():
+        if p.metadata is not None:
+            setattr(p.metadata, "rendered_wav", str(out))
+    return out

--- a/utilities/cc_tools.py
+++ b/utilities/cc_tools.py
@@ -62,7 +62,10 @@ def merge_cc_events(
     for t, c, v in more_set:
         result[(float(t), int(c))] = int(v)
 
-    merged = [(t, c, v) for (t, c), v in sorted(result.items())]
+    merged = [
+        (t, c, v)
+        for (t, c), v in sorted(result.items(), key=lambda x: (x[0][0], x[0][1]))
+    ]
     if as_dict:
         return [{"time": t, "cc": c, "val": v} for (t, c, v) in merged]
     return merged

--- a/utilities/effect_preset_loader.py
+++ b/utilities/effect_preset_loader.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class EffectPresetLoader:
+    _LIB: dict[str, dict] = {}
+    _PATH: Path | None = None
+
+    @classmethod
+    def load(cls, path: str) -> None:
+        p = Path(path)
+        cls._PATH = p
+        try:
+            with open(p, "r", encoding="utf-8") as fh:
+                if p.suffix.lower() == ".json":
+                    data = json.load(fh)
+                else:
+                    data = yaml.safe_load(fh)
+        except Exception as exc:  # pragma: no cover - optional
+            logger.error("Failed to load effect presets %s: %s", path, exc)
+            return
+        if isinstance(data, dict):
+            cls._LIB = {str(k): dict(v) for k, v in data.items() if isinstance(v, dict)}
+        else:
+            cls._LIB = {}
+
+    @classmethod
+    def get(cls, name: str) -> dict | None:
+        preset = cls._LIB.get(name)
+        if preset is None:
+            logger.warning("Effect preset '%s' not found", name)
+        return preset
+
+    @classmethod
+    def reload(cls) -> None:
+        """Reload the preset file if previously loaded."""
+        if cls._PATH is not None:
+            cls.load(str(cls._PATH))

--- a/utilities/mix_profile.py
+++ b/utilities/mix_profile.py
@@ -41,7 +41,10 @@ def export_mix_json(parts, path: str) -> None:
             if ir_file is not None:
                 entry["ir_file"] = str(Path(ir_file))
             rendered = getattr(meta, "rendered_wav", None)
-            if rendered is not None:
+            is_strings = any(
+                kw in name.lower() for kw in ["violin", "cello", "viola", "bass", "strings"]
+            )
+            if rendered is not None and is_strings:
                 entry["rendered_wav"] = str(rendered)
             fx_env = getattr(meta, "fx_envelope", None)
             if fx_env:


### PR DESCRIPTION
## Summary
- add effect preset loader reload and warn on missing preset
- extend audio render and mix profile utilities for strings
- support strings IR rendering in CLI and docs
- run audio tests in packaging workflow
- test effect preset loader

## Testing
- `pytest -q tests/test_strings_effects.py tests/test_strings_audio_export.py tests/test_mix_profile.py tests/test_effect_preset_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686eca26419883288bdfda19e1eaea9c