### PR TITLE
Fix ToneShaper IR guard

### DIFF
--- a/utilities/tone_shaper.py
+++ b/utilities/tone_shaper.py
@@ -214,6 +214,8 @@ class ToneShaper:
             if not p.is_file():
                 if os.getenv("IGNORE_MISSING_IR", "0") != "1":
                     logger.warning("IR file missing: %s", path_str)
+                if os.getenv("IGNORE_MISSING_IR", "0") == "1":
+                    continue
             ir_map[name] = p
 
         return cls(preset_map=preset_map, ir_map=ir_map, rules=rules)


### PR DESCRIPTION
## Summary
- ignore missing IRs in ToneShaper.from_yaml when `IGNORE_MISSING_IR=1`
- verified tests pass with no section lookup warning or `step 16` logs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f03fddc4c8328bc7b05eb02b421d1