### PR TITLE
Reduce test warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 testpaths =
     tests
     tools
-norecursedirs = .git .hg .svn _build tmp* .venv アーカイブ
+norecursedirs = .git .hg .svn _build tmp* .venv アーカイブ .hypothesis
 addopts = --dry-run
 markers =
     ess_optional: tests that require the Essentia backend
@@ -26,3 +26,9 @@ markers =
 filterwarnings =
     ignore::music21.exceptions21.Music21DeprecationWarning
     ignore::DeprecationWarning
+    ignore::sklearn.exceptions.ConvergenceWarning
+    ignore:hdbscan not installed; using Jaccard dedupe fallback:RuntimeWarning
+    ignore:unknown aux.*:RuntimeWarning
+    ignore:aux hash collision detected.*:RuntimeWarning
+    ignore:SHA-1 collision.*:RuntimeWarning
+    ignore::pydantic.deprecated.PydanticDeprecatedSince20

--- a/tests/test_empty_aux_backoff.py
+++ b/tests/test_empty_aux_backoff.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import warnings
 import pretty_midi
 
 from utilities import groove_sampler_ngram as gs
@@ -16,6 +17,8 @@ def test_unknown_aux_fallback(tmp_path: Path) -> None:
     _make_loop(tmp_path / "verse.mid")
     aux_map = {"verse.mid": {"section": "verse", "heat_bin": 0, "intensity": "mid"}}
     model = gs.train(tmp_path, aux_map=aux_map, order=1)
-    events = gs.sample(model, bars=1, cond={"section": "bridge"})
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        events = gs.sample(model, bars=1, cond={"section": "bridge"})
     assert events
 

--- a/tests/test_hash_collision_fail.py
+++ b/tests/test_hash_collision_fail.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest import mock
 
 from utilities import groove_sampler_ngram
+import warnings
 from tests.test_hash_collision import _make_loop
 
 
@@ -14,6 +15,8 @@ def test_hash_collision_fail(monkeypatch: mock.MagicMock, tmp_path: Path) -> Non
         return 1
 
     monkeypatch.setattr(groove_sampler_ngram, "_hash_bytes", const_hash)
-    with pytest.raises(RuntimeError):
-        groove_sampler_ngram.train(tmp_path, order=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.raises(RuntimeError):
+            groove_sampler_ngram.train(tmp_path, order=1)
 

--- a/tests/test_lin_prob_lru.py
+++ b/tests/test_lin_prob_lru.py
@@ -1,9 +1,17 @@
 from random import Random
 
 from utilities import groove_sampler_ngram as n
+import warnings
 
 
 def _simple_model() -> n.Model:
+    aux_val = n._hash_aux(
+        (
+            n.DEFAULT_AUX["section"],
+            str(n.DEFAULT_AUX["heat_bin"]),
+            n.DEFAULT_AUX["intensity"],
+        )
+    )
     return {
         "version": n.VERSION,
         "resolution": n.RESOLUTION,
@@ -13,7 +21,11 @@ def _simple_model() -> n.Model:
         "mean_velocity": {},
         "vel_deltas": {},
         "micro_offsets": {},
-        "aux_cache": {},
+        "aux_cache": {aux_val: (
+            n.DEFAULT_AUX["section"],
+            str(n.DEFAULT_AUX["heat_bin"]),
+            n.DEFAULT_AUX["intensity"],
+        )},
         "use_sha1": False,
         "num_tokens": 1,
         "train_perplexity": 0.0,
@@ -27,5 +39,7 @@ def test_lin_prob_lru() -> None:
     n._lin_prob.clear()
     for i in range(3000):
         hist = [(i, "kick")]
-        n._sample_next(hist, model, rng, top_k=None)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            n._sample_next(hist, model, rng, top_k=None)
     assert len(n._lin_prob) <= n.MAX_CACHE

--- a/tests/test_ngram_aux_unseen.py
+++ b/tests/test_ngram_aux_unseen.py
@@ -1,4 +1,5 @@
 import pretty_midi
+import warnings
 from pathlib import Path
 
 from utilities import groove_sampler_ngram
@@ -20,5 +21,7 @@ def test_unseen_aux_fallback(tmp_path: Path) -> None:
     _make_loop(loop)
     aux_map = {"verse.mid": {"section": "verse", "heat_bin": 0, "intensity": "mid"}}
     model = groove_sampler_ngram.train(tmp_path, aux_map=aux_map, order=1)
-    events = groove_sampler_ngram.sample(model, bars=1, cond={"section": "bridge"})
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        events = groove_sampler_ngram.sample(model, bars=1, cond={"section": "bridge"})
     assert events


### PR DESCRIPTION
## Summary
- update pytest configuration to ignore common runtime warnings
- silence warnings in a few sampler tests
- add aux cache entry in lin prob LRU test

## Testing
- `bash setup.sh` *(fails: attempted heavy dependency installation)*
- `pytest -q` *(fails: missing `fastapi` and others)*

------
https://chatgpt.com/codex/tasks/task_e_686f16437804832897657e26f8b555c0