### PR TITLE
Improve convolution pipeline

### DIFF
--- a/docs/audio_pipeline.md
+++ b/docs/audio_pipeline.md
@@ -1,0 +1,24 @@
+# Audio Pipeline Enhancements
+
+The convolution engine now performs fast FFT convolution with optional
+oversampling and high quality sample‑rate conversion. Specify the
+quality level (`fast`, `high`, or `ultra`) to control the resampler.
+For oversampling, signals are resampled up by 2× or 4× before the IR is
+applied and filtered back down to minimise aliasing.
+
+Tail handling detects when the convolved signal falls below the given
+`tail_db_drop` threshold (default `-60` dB) and applies a short
+cross‑fade to silence. When exporting to 16‑, 24‑ or 32‑bit PCM, TPDF dither
+is applied automatically.
+
+Use the new options via `render_wav` or the command line interface to
+fine‑tune quality and bit depth.
+
+Bit depth can be `16`, `24`, or `32` (float). Dithering is skipped when
+normalization is disabled or with `--no-dither`.
+
+| quality | resampler | window/setting |
+| ------- | --------- | -------------- |
+| fast    | soxr `q` or Kaiser 8 | quick |
+| high    | soxr `hq` or Kaiser 8 | high quality |
+| ultra   | soxr `vhq` or Kaiser 16 | very high quality |

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -68,7 +68,8 @@ gen.export_musicxml_tab("out_tab.xml")
 MIDI から直接 WAV を生成し、インパルス応答を適用するには `modcompose ir-render` を使用します。
 
 ```bash
-modcompose ir-render part.mid irs/room.wav -o rendered.wav
+modcompose ir-render part.mid irs/room.wav -o rendered.wav \
+  --quality high --bit-depth 32 --oversample 2 --no-dither
 ```
 
 Python からは ``GuitarGenerator.export_audio`` を使って IR 名を指定できます。

--- a/generator/guitar_generator.py
+++ b/generator/guitar_generator.py
@@ -2359,7 +2359,6 @@ class GuitarGenerator(BasePartGenerator):
         from tempfile import NamedTemporaryFile
 
         from utilities.audio_render import render_part_audio
-        from utilities import mix_profile
 
         part = getattr(self, "_last_part", None)
         if part is None:

--- a/generator/strings_generator.py
+++ b/generator/strings_generator.py
@@ -1298,7 +1298,13 @@ class StringsGenerator(BasePartGenerator):
             name = sec.get("section_name", "section")
             out_path = Path("out") / f"strings_{name}.wav"
 
-        return render_part_audio(parts, ir_name=ir_name, out_path=out_path, sf2=sf2, **mix_opts)
+        return render_part_audio(
+            parts,
+            ir_name=ir_name,
+            out_path=out_path,
+            sf2=sf2,
+            **mix_opts,
+        )
 
 
 def generate_cc_automation(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
   - Effects & Automation:
       - Overview: effects.md
       - Offline IR Convolution: offline_ir.md
+      - Audio Pipeline: audio_pipeline.md
   - Tone & Dynamics: tone.md
   - Piano Delta: piano_delta.md
   - Piano Epsilon: piano_epsilon.md

--- a/tests/test_audio_render.py
+++ b/tests/test_audio_render.py
@@ -1,0 +1,43 @@
+import importlib.util
+import types
+import numpy as np
+from pathlib import Path
+
+if importlib.util.find_spec("soundfile") is None:
+    sf = types.SimpleNamespace(
+        write=lambda p, d, sr, subtype=None: Path(p).write_bytes(b""),
+        info=lambda p: types.SimpleNamespace(samplerate=44100, subtype="PCM_16"),
+        read=lambda p: (np.zeros(1, dtype=np.float32), 44100),
+    )
+else:
+    import soundfile as sf
+
+from music21 import stream, note
+
+from utilities.audio_render import render_part_audio
+
+
+def _make_part():
+    p = stream.Part()
+    p.append(note.Note('C4', quarterLength=1))
+    return p
+
+
+import pytest
+
+
+@pytest.mark.parametrize("soxr_present", [True, False])
+def test_render_part_audio_options(tmp_path, monkeypatch, soxr_present):
+    import utilities.convolver as conv
+    if not soxr_present:
+        monkeypatch.setattr(conv, "soxr", None)
+    part = _make_part()
+    for q in ["high", "ultra"]:
+        for b in [16, 24, 32]:
+            out = tmp_path / f"out_{q}_{b}.wav"
+            render_part_audio(part, out_path=out, quality=q, bit_depth=b, oversample=4)
+            info = sf.info(out)
+            assert info.samplerate == 44100
+            subtype = "FLOAT" if b == 32 else f"PCM_{b}"
+            assert info.subtype == subtype
+            assert out.is_file()

--- a/tests/test_cli_ir_render.py
+++ b/tests/test_cli_ir_render.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+import importlib.util
+import types
+import numpy as np
+
+if importlib.util.find_spec("soundfile") is None:
+    sf = types.SimpleNamespace(
+        write=lambda p, d, sr: Path(p).write_bytes(b""),
+    )
+else:
+    import soundfile as sf
+import importlib
+
+import modular_composer.cli as cli
+
+
+def _write_midi(path: Path) -> None:
+    path.write_bytes(b"MThd\x00\x00\x00\x06\x00\x01\x00\x01\x00\x60MTrk\x00\x00\x00\x04\x00\xFF\x2F\x00")
+
+
+def test_cli_ir_render_modes(tmp_path, monkeypatch):
+    midi = tmp_path / "a.mid"
+    _write_midi(midi)
+    ir = tmp_path / "ir.wav"
+    sf.write(ir, [1.0], 44100)
+    out = tmp_path / "out.wav"
+
+    monkeypatch.setattr(cli, "has_fluidsynth", lambda: True)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: True)
+
+    captured = []
+
+    def fake_render_wav(m, i, o, **kw):
+        captured.append(kw["quality"])
+        Path(o).write_text("ok")
+
+    monkeypatch.setattr(cli, "render_wav", fake_render_wav)
+
+    for q in ["fast", "high", "ultra"]:
+        monkeypatch.setattr(sys, "argv", [
+            "modcompose",
+            "ir-render",
+            str(midi),
+            str(ir),
+            "-o",
+            str(out),
+            "--quality",
+            q,
+        ])
+        cli.main()
+        assert out.is_file()
+        out.unlink()
+    assert captured == ["fast", "high", "ultra"]

--- a/tests/test_ir_convolution.py
+++ b/tests/test_ir_convolution.py
@@ -1,0 +1,11 @@
+import numpy as np
+from utilities.convolver import convolve_ir
+
+
+def test_fft_equals_numpy():
+    rng = np.random.default_rng(0)
+    audio = rng.normal(size=32).astype(np.float32)
+    ir = rng.normal(size=8).astype(np.float32)
+    out = convolve_ir(audio, ir)
+    ref = np.convolve(audio, ir)[: len(audio) + len(ir) - 1]
+    assert np.allclose(out[:, 0], ref, atol=1e-6)

--- a/tests/test_ir_sr_channels.py
+++ b/tests/test_ir_sr_channels.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+import soundfile as sf
+
+from utilities.convolver import render_with_ir
+
+
+@pytest.mark.parametrize("sr", [44100, 96000, 192000])
+@pytest.mark.parametrize("channels", [1, 2, 4])
+def test_ir_sr_and_channels(tmp_path, monkeypatch, sr, channels):
+    import utilities.convolver as conv
+
+    monkeypatch.setattr(conv, "soxr", None)
+
+    audio = np.zeros(int(sr * 0.01), dtype=np.float32)
+    audio[0] = 1.0
+    inp = tmp_path / "in.wav"
+    sf.write(inp, audio, sr)
+
+    ir = np.zeros((int(sr * 0.01), channels), dtype=np.float32)
+    ir[0] = 1.0
+    ir_path = tmp_path / "ir.wav"
+    sf.write(ir_path, ir, sr)
+
+    out = tmp_path / "out.wav"
+    render_with_ir(inp, ir_path, out, normalize=False)
+
+    data, out_sr = sf.read(out, always_2d=True)
+    assert out_sr == 44100
+    expected_ch = 1 if channels == 1 else 2
+    assert data.shape[1] == expected_ch

--- a/tests/test_oversample_tail.py
+++ b/tests/test_oversample_tail.py
@@ -1,0 +1,27 @@
+import numpy as np
+import soundfile as sf
+from utilities.convolver import render_with_ir
+
+
+def test_oversample_tail(tmp_path):
+    sr = 44100
+    dur = 0.25
+    audio = np.zeros(int(sr * dur), dtype=np.float32)
+    audio[0] = 1.0
+    ir = np.exp(-np.linspace(0, 1.0, int(sr * dur))).astype(np.float32)
+    wav = tmp_path / "dry.wav"
+    irwav = tmp_path / "ir.wav"
+    out = tmp_path / "out.wav"
+    sf.write(wav, audio, sr)
+    sf.write(irwav, ir, sr)
+    render_with_ir(wav, irwav, out, oversample=2, normalize=False, tail_db_drop=-40)
+    data, _ = sf.read(out)
+    assert len(data) > len(audio)
+    tail_db = 20 * np.log10(abs(data[-1]) / max(abs(data)))
+    assert tail_db < -40
+    peak = max(abs(data))
+    thresh = peak * (10 ** (-40 / 20.0))
+    idx = np.where(np.abs(data) > thresh)[0]
+    start = idx[-1] if idx.size else 0
+    fade_len = len(data) - start
+    assert abs(fade_len - int(sr * 0.01)) <= 2

--- a/utilities/audio_render.py
+++ b/utilities/audio_render.py
@@ -12,10 +12,16 @@ from .mix_profile import get_mix_chain
 
 def render_part_audio(
     part: stream.Part | Mapping[str, stream.Part],
-    ir_name: str | None = None,
-    out_path: str | Path | None = None,
     *,
+    ir_name: str | None = None,
+    out_path: str | Path | None = "out.wav",
     sf2: str | None = None,
+    quality: str = "fast",
+    bit_depth: int = 24,
+    oversample: int = 1,
+    normalize: bool = True,
+    dither: bool = True,
+    tail_db_drop: float = -60.0,
     **mix_opts,
 ) -> Path:
     """Render ``part`` to ``out_path`` applying ``ir_name`` if given."""
@@ -45,7 +51,23 @@ def render_part_audio(
     if out_path is None:
         out_path = "out.wav"
 
-    out = render_wav(tmp_mid.name, ir_file or "", str(out_path), sf2=sf2, parts=parts, **mix_opts)
+    if bit_depth not in (16, 24, 32):
+        raise ValueError("bit_depth must be 16, 24, or 32")
+
+    out = render_wav(
+        tmp_mid.name,
+        ir_file or "",
+        str(out_path),
+        sf2=sf2,
+        parts=parts,
+        quality=quality,
+        bit_depth=bit_depth,
+        oversample=oversample,
+        normalize=normalize,
+        dither=dither,
+        tail_db_drop=tail_db_drop,
+        **mix_opts,
+    )
 
     Path(tmp_mid.name).unlink(missing_ok=True)
     for p in parts.values():

--- a/utilities/convolver.py
+++ b/utilities/convolver.py
@@ -1,183 +1,122 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from pathlib import Path
 
 import numpy as np
 from music21 import stream
 
 try:
-    import soundfile as sf
+    import soundfile as sf  # type: ignore
 except Exception:  # pragma: no cover - optional
     sf = None  # type: ignore
-from scipy.signal import fftconvolve
+
+try:
+    import soxr  # type: ignore
+except Exception:  # pragma: no cover - optional
+    soxr = None  # type: ignore
+
+from scipy.signal import resample_poly
 
 try:
     import pyloudnorm as pyln  # type: ignore
 except Exception:  # pragma: no cover - optional
     pyln = None  # type: ignore
-try:
-    import soxr  # type: ignore
-except Exception:  # pragma: no cover - optional
-    soxr = None  # type: ignore
-    try:
-        from scipy.signal import resample_poly  # type: ignore
-    except Exception:  # pragma: no cover - optional
-        resample_poly = None  # type: ignore
-else:
-    resample_poly = None  # type: ignore
-try:
-    if sf is not None:
-        try:
-            sf.default_subtype("WAV", subtype="FLOAT")  # type: ignore[arg-type]
-        except TypeError:
-            # Older soundfile versions only expose a mapping
-            if hasattr(sf, "_default_subtypes"):
-                sf._default_subtypes["WAV"] = "FLOAT"  # type: ignore[attr-defined]
-except Exception:
-    pass
+
 try:
     from tqdm import tqdm  # type: ignore
 except Exception:  # pragma: no cover - optional
 
     class _NoTqdm:
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            return
+        def __init__(self, *a: object, **k: object) -> None: ...
+        def update(self, *a: object, **k: object) -> None: ...
+        def close(self) -> None: ...
 
-        def update(self, *args: object, **kwargs: object) -> None:
-            return
-
-        def close(self) -> None:
-            return
-
-    def tqdm(*args: object, **kwargs: object) -> _NoTqdm:  # type: ignore
+    def tqdm(*a: object, **k: object) -> _NoTqdm:  # type: ignore
         return _NoTqdm()
 
 
 logger = logging.getLogger(__name__)
 
 
-def _write_gain(
-    data: np.ndarray, sr: int, path: Path, gain_db: float, bit_depth: str
-) -> None:
-    """Write *data* to *path* applying gain and normalisation."""
-    if sf is None:
-        raise RuntimeError("soundfile is required for WAV rendering")
-    if gain_db:
-        data = data * (10 ** (gain_db / 20.0))
-    peak = np.max(np.abs(data))
-    if peak > 1.0:
-        data = data / peak
-    subtype_map = {"16": "PCM_16", "24": "PCM_24", "32f": "FLOAT"}
-    subtype = subtype_map.get(bit_depth, "PCM_16")
-    sf.write(path, data.astype(np.float32), sr, subtype=subtype)
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
 
 
-def render_with_ir(
-    input_wav: str | Path,
-    ir_wav: str | Path,
-    out_wav: str | Path,
-    *,
-    lufs_target: float | None = None,
-    gain_db: float | None = None,
+def _next_pow2(n: int) -> int:
+    return 1 << (n - 1).bit_length()
+
+
+def _resample(data: np.ndarray, src: int, dst: int, *, quality: str) -> np.ndarray:
+    if src == dst:
+        return data
+    if soxr is not None:
+        qmap = {"fast": soxr.QQ, "high": soxr.HQ, "ultra": soxr.VHQ}
+        return soxr.resample(data, src, dst, quality=qmap.get(quality, soxr.QQ))
+    window = ("kaiser", 16.0) if quality == "ultra" else ("kaiser", 8.0)
+    from math import gcd
+
+    up, down = dst, src
+    g = gcd(up, down)
+    up //= g
+    down //= g
+    try:
+        res = resample_poly(data.astype(np.float64), up, down, axis=0, window=window)
+    except TypeError:  # pragma: no cover - older SciPy
+        res = resample_poly(data.astype(np.float64), up, down, axis=0)
+    return res.astype(data.dtype, copy=False)
+
+
+def _fft_convolve(sig: np.ndarray, ir: np.ndarray) -> np.ndarray:
+    n = len(sig) + len(ir) - 1
+    nfft = _next_pow2(n)
+    S = np.fft.rfft(sig, nfft)
+    H = np.fft.rfft(ir, nfft)
+    y = np.fft.irfft(S * H, nfft)[:n]
+    return y
+
+
+def convolve_ir(
+    audio: np.ndarray,
+    ir: np.ndarray,
     block_size: int = 2**14,
-    bit_depth: str = "16",
+    *,
     progress: bool = False,
-) -> None:
-    """Convolve ``input_wav`` with ``ir_wav`` and write to ``out_wav``.
-
-    If sample rates differ, both are resampled to 44100 Hz using soxr when
-    available. Mono IRs are broadcast to stereo. The result is normalised,
-    optionally amplified, and loudness-adjusted toward ``lufs_target``.
-    """
-
-    if sf is None:
-        raise RuntimeError("soundfile is required for render_with_ir")
-    inp = Path(input_wav)
-    irp = Path(ir_wav)
-    out = Path(out_wav)
-    if gain_db is None:
-        gain_db = 0.0
-
-    try:
-        y, sr = sf.read(inp, always_2d=True)
-    except (FileNotFoundError, OSError) as exc:  # pragma: no cover - best effort
-        logger.warning("Failed to read WAV: %s", exc)
-        return
-
-    if not irp.is_file():
-        logger.warning("IR file missing: %s", ir_wav)
-        if y.shape[1] == 1:
-            y = np.broadcast_to(y, (y.shape[0], 2))
-        _write_gain(y, sr, out, gain_db, bit_depth)
-        return
-
-    try:
-        ir, ir_sr = sf.read(irp, always_2d=True)
-    except (FileNotFoundError, OSError) as exc:  # pragma: no cover - best effort
-        logger.warning("Failed to read IR: %s", exc)
-        _write_gain(y, sr, out, gain_db, bit_depth)
-        return
-
-    if sr != ir_sr:
-        target_sr = 44100
-        if soxr is not None:
-            y = soxr.resample(y, sr, target_sr, quality="mq")
-            ir = soxr.resample(ir, ir_sr, target_sr, quality="mq")
-        else:
-            if resample_poly is None:
-                from scipy.signal import resample_poly as _rp
-
-                y = _rp(y, target_sr, sr, axis=0)
-                ir = _rp(ir, target_sr, ir_sr, axis=0)
-            else:
-                y = resample_poly(y, target_sr, sr, axis=0)
-                ir = resample_poly(ir, target_sr, ir_sr, axis=0)
-        sr = ir_sr = target_sr
-
-    if ir.shape[1] == 1 and y.shape[1] > 1:
-        ir = np.broadcast_to(ir, (ir.shape[0], y.shape[1]))
-    if y.shape[1] == 1 and ir.shape[1] > 1:
-        y = np.broadcast_to(y, (y.shape[0], ir.shape[1]))
-
-    if y.shape[0] > 2**18:
-        data = convolve_ir(y, ir, block_size=block_size, progress=progress)
-    else:
-        channels = max(y.shape[1], ir.shape[1])
-        out_data = []
-        bar = tqdm(total=channels, disable=not progress, desc="IR", leave=False)
+) -> np.ndarray:
+    """Overlap-add FFT convolution returning ``len(audio)+len(ir)-1`` samples."""
+    if audio.ndim == 1:
+        audio = audio[:, None]
+    if ir.ndim == 1:
+        ir = ir[:, None]
+    out_len = audio.shape[0] + ir.shape[0] - 1
+    channels = max(audio.shape[1], ir.shape[1])
+    if ir.shape[0] < 2**14:
+        result = []
         for ch in range(channels):
-            s = y[:, ch] if y.shape[1] > 1 else y[:, 0]
+            s = audio[:, ch] if audio.shape[1] > 1 else audio[:, 0]
             h = ir[:, ch] if ir.shape[1] > 1 else ir[:, 0]
-            conv = fftconvolve(s, h)[: len(s)]
-            out_data.append(conv)
-            bar.update(1)
-        bar.close()
+            result.append(_fft_convolve(s, h))
+        return np.stack(result, axis=1)[:out_len]
 
-        data = np.stack(out_data, axis=1)
-    rms_in = np.sqrt(np.mean(np.square(y)))
-    rms_out = np.sqrt(np.mean(np.square(data)))
-    if rms_out > 0:
-        data = data * (rms_in / rms_out)
-
-    lufs = None
-    if lufs_target is not None and pyln is not None:
-        meter = pyln.Meter(sr)
-        lufs = float(meter.integrated_loudness(data))
-        diff = lufs_target - lufs
-        diff = min(3.0, max(-3.0, diff))
-        data = data * (10 ** (diff / 20.0))
-        lufs = float(meter.integrated_loudness(data))
-
-    _write_gain(data, sr, out, gain_db, bit_depth)
-    if lufs is None and lufs_target is not None:
-        lufs = lufs_target
-    logger.info(
-        "\u2713 Convolved %.1f s IR \u2192 %s (%.1f LUFS)",
-        len(ir) / sr,
-        out,
-        lufs if lufs is not None else -0.0,
-    )
+    fft_size = _next_pow2(ir.shape[0] * 2)
+    hop = fft_size - ir.shape[0] + 1
+    H = np.fft.rfft(ir, fft_size, axis=0)
+    result = np.zeros((out_len + hop, channels), dtype=np.float64)
+    pos = 0
+    bar = tqdm(total=audio.shape[0], disable=not progress, desc="IR", leave=False)
+    while pos < audio.shape[0]:
+        chunk = audio[pos : pos + hop]
+        buf = np.zeros((fft_size, audio.shape[1]), dtype=np.float64)
+        buf[: chunk.shape[0]] = chunk
+        X = np.fft.rfft(buf, axis=0)
+        y = np.fft.irfft(X * H, axis=0)
+        result[pos : pos + fft_size, : audio.shape[1]] += y
+        pos += hop
+        bar.update(chunk.shape[0])
+    bar.close()
+    return result[:out_len].astype(np.float32)
 
 
 def load_ir(path: str) -> tuple[np.ndarray, int]:
@@ -190,40 +129,156 @@ def load_ir(path: str) -> tuple[np.ndarray, int]:
     return data.astype(np.float32), int(sr)
 
 
-def convolve_ir(
-    audio: np.ndarray,
-    ir: np.ndarray,
-    block_size: int = 2**14,
-    *,
-    progress: bool = False,
+def _apply_tpdf_dither(data: np.ndarray, bit_depth: int) -> np.ndarray:
+    if bit_depth == 32:
+        return data
+    if bit_depth not in (16, 24):
+        return data
+    lsb = 1.0 / (2 ** (bit_depth - 1))
+    noise = (np.random.random(data.shape) - 0.5) + (np.random.random(data.shape) - 0.5)
+    return data + noise * lsb
+
+
+def _fade_tail(
+    data: np.ndarray, drop_db: float, sr: int, ms: float = 10.0
 ) -> np.ndarray:
-    """Overlap-add FFT convolution returning the input length."""
-    if audio.ndim == 1:
-        audio = audio[:, None]
-    if ir.ndim == 1:
-        ir = ir[:, None]
-    out_len = audio.shape[0] + ir.shape[0] - 1
-    channels = max(audio.shape[1], ir.shape[1])
-    result = np.zeros((out_len, channels), dtype=np.float64)
-    fft_size = 1 << int(np.ceil(np.log2(block_size + ir.shape[0] - 1)))
-    H = np.fft.rfft(ir, fft_size, axis=0)
-    pos = 0
-    bar = tqdm(total=audio.shape[0], disable=not progress, desc="IR", leave=False)
-    while pos < audio.shape[0]:
-        chunk = audio[pos : pos + block_size]
-        pad = np.zeros((fft_size, audio.shape[1]), dtype=np.float64)
-        pad[: chunk.shape[0]] = chunk
-        X = np.fft.rfft(pad, axis=0)
-        y = np.fft.irfft(X * H, axis=0)[:fft_size]
-        result[pos : pos + fft_size, : audio.shape[1]] += y
-        pos += block_size
-        bar.update(chunk.shape[0])
-    bar.close()
-    return result[: audio.shape[0]].astype(np.float32)
+    if data.ndim > 1:
+        mag = np.max(np.abs(data), axis=1)
+    else:
+        mag = np.abs(data)
+    peak = float(np.max(mag))
+    if peak == 0:
+        return data
+    thresh = peak * (10 ** (drop_db / 20.0))
+    idx = np.where(mag > thresh)[0]
+    if idx.size == 0:
+        start = 0
+        fade_len = len(data)
+    else:
+        start = idx[-1]
+        fade_len = min(len(data) - start, int(sr * ms / 1000.0))
+    if fade_len <= 0:
+        return data
+    fade = np.linspace(1.0, 0.0, fade_len)
+    if data.ndim > 1:
+        fade = fade[:, None]
+    out = data.copy()
+    out[start : start + fade_len] *= fade
+    return out[: start + fade_len]
+
+
+def _quantize_pcm(data: np.ndarray, bit_depth: int) -> tuple[np.ndarray, str]:
+    """Return integer PCM array and subtype."""
+    if bit_depth == 32:
+        return data.astype(np.float32), "FLOAT"
+    max_val = float(2 ** (bit_depth - 1) - 1)
+    min_val = -max_val - 1
+    q = np.clip(np.round(data * max_val), min_val, max_val)
+    if bit_depth == 24:
+        return q.astype(np.int32), "PCM_24"
+    return q.astype(np.int16), "PCM_16"
+
+
+def render_with_ir(
+    input_wav: str | Path,
+    ir_wav: str | Path,
+    out_wav: str | Path,
+    *,
+    lufs_target: float | None = None,
+    gain_db: float | None = None,
+    block_size: int = 2**14,
+    bit_depth: int = 24,
+    quality: str = "fast",
+    oversample: int = 1,
+    normalize: bool = True,
+    dither: bool = True,
+    tail_db_drop: float = -60.0,
+    progress: bool = False,
+) -> Path:
+    """Convolve ``input_wav`` with ``ir_wav`` and write to ``out_wav``."""
+
+    if sf is None:
+        raise RuntimeError("soundfile is required for render_with_ir")
+
+    inp = Path(input_wav)
+    irp = Path(ir_wav)
+    out = Path(out_wav)
+    gain_db = gain_db or 0.0
+
+    try:
+        y, sr = sf.read(inp, always_2d=True)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("Failed to read WAV: %s", exc)
+        return out
+
+    if not irp.is_file():
+        logger.warning("IR file missing: %s", ir_wav)
+        if y.shape[1] == 1:
+            y = np.broadcast_to(y, (y.shape[0], 2))
+        pcm, subtype = _quantize_pcm(_apply_tpdf_dither(y, bit_depth), bit_depth)
+        sf.write(out, pcm, sr, subtype=subtype)
+        return out
+
+    ir, ir_sr = sf.read(irp, always_2d=True)
+    target_sr = 44100
+    y = _resample(y, sr, target_sr, quality=quality)
+    ir = _resample(ir, ir_sr, target_sr, quality=quality)
+    sr = target_sr
+
+    if ir.shape[1] > 2:
+        mid = ir.shape[1] // 2
+        left = ir[:, :mid].mean(axis=1)
+        right = ir[:, mid:].mean(axis=1)
+        ir = np.stack([left, right], axis=1)
+
+    if oversample > 1:
+        y = _resample(y, sr, sr * oversample, quality=quality)
+        ir = _resample(ir, sr, sr * oversample, quality=quality)
+        sr *= oversample
+
+    if ir.shape[1] == 1 and y.shape[1] > 1:
+        ir = np.broadcast_to(ir, (ir.shape[0], y.shape[1]))
+    if y.shape[1] == 1 and ir.shape[1] > 1:
+        y = np.broadcast_to(y, (y.shape[0], ir.shape[1]))
+
+    data = convolve_ir(y, ir, block_size=block_size, progress=progress)
+    if oversample > 1:
+        data = _resample(data, sr, sr // oversample, quality=quality)
+        sr //= oversample
+
+    data = _fade_tail(data, tail_db_drop, sr)
+
+    if normalize:
+        peak = float(np.max(np.abs(data)))
+        if peak > 0:
+            data = data / peak
+    else:
+        dither = False
+
+    if gain_db:
+        data = data * (10 ** (gain_db / 20.0))
+
+    if lufs_target is not None:
+        if pyln is None:
+            logger.warning("pyloudnorm not installed; skipping LUFS normalization")
+        else:
+            try:
+                meter = pyln.Meter(sr)
+                diff = lufs_target - float(meter.integrated_loudness(data))
+                diff = max(-3.0, min(3.0, diff))
+                data = data * (10 ** (diff / 20.0))
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.debug("pyloudnorm failed: %s", exc)
+
+    if dither:
+        data = _apply_tpdf_dither(data, bit_depth)
+    pcm, subtype = _quantize_pcm(data, bit_depth)
+    sf.write(out, pcm, sr, subtype=subtype)
+    return out
 
 
 def normalize_velocities(parts: list[stream.Part] | dict[str, stream.Part]) -> None:
-    """Scale note velocities of *parts* so averages match."""
+    """Scale note velocities of ``parts`` so averages match."""
     if isinstance(parts, dict):
         all_parts = list(parts.values())
     else:
@@ -233,9 +288,8 @@ def normalize_velocities(parts: list[stream.Part] | dict[str, stream.Part]) -> N
     avgs = []
     for p in all_parts:
         vals = [n.volume.velocity or 0 for n in p.recurse().notes if n.volume]
-        if not vals:
-            continue
-        avgs.append(sum(vals) / len(vals))
+        if vals:
+            avgs.append(sum(vals) / len(vals))
     if not avgs:
         return
     target = sum(avgs) / len(avgs)
@@ -260,7 +314,13 @@ def render_wav(
     out_path: str,
     sf2: str | None = None,
     *,
-    parts: list[stream.Part] | dict[str, stream.Part] | None = None,
+    parts: Iterable[stream.Part] | dict[str, stream.Part] | None = None,
+    quality: str = "fast",
+    bit_depth: int = 24,
+    oversample: int = 1,
+    normalize: bool = True,
+    dither: bool = True,
+    tail_db_drop: float = -60.0,
     **mix_opts,
 ) -> Path:
     """Render ``midi_path`` with ``fluidsynth`` and apply ``ir_path``."""
@@ -271,9 +331,11 @@ def render_wav(
 
     tmp_midi: Path | None = None
     if parts is not None:
-        normalize_velocities(parts)
+        normalize_velocities(
+            list(parts.values()) if isinstance(parts, dict) else list(parts)
+        )
         score = stream.Score()
-        for p in (parts.values() if isinstance(parts, dict) else parts):
+        for p in parts.values() if isinstance(parts, dict) else parts:
             score.insert(0, p)
         tmp_midi = Path(out_path).with_suffix(".norm.mid")
         score.write("midi", fp=str(tmp_midi))
@@ -283,19 +345,18 @@ def render_wav(
 
     tmp = Path(out_path).with_suffix(".dry.wav")
     render_midi(midi_in, tmp, sf2_path=sf2)
-    audio, sr = sf.read(tmp, dtype="float32")
-    ir, ir_sr = load_ir(ir_path)
-    if sr != ir_sr:
-        from scipy.signal import resample
-
-        ir = resample(ir, int(len(ir) * sr / ir_sr))
-    if ir.ndim == 1:
-        ir = ir[:, None]
-    out = convolve_ir(audio, ir, block_size=mix_opts.get("block_size", 2**14))
-    peak = np.max(np.abs(out))
-    if peak > 0:
-        out = out / peak
-    sf.write(out_path, (out * 32767).astype(np.int16), sr)
+    render_with_ir(
+        tmp,
+        ir_path,
+        out_path,
+        quality=quality,
+        bit_depth=bit_depth,
+        oversample=oversample,
+        normalize=normalize,
+        dither=dither,
+        tail_db_drop=tail_db_drop,
+        **mix_opts,
+    )
     tmp.unlink(missing_ok=True)
     if tmp_midi is not None:
         tmp_midi.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- enable 32‑bit output and optional dither in the convolution pipeline
- use 10 ms fade tails and quality options through CLI
- handle missing deps in tests with stubs
- document new bit-depth and dither controls
- add safety for multi-channel IRs and resample edge cases

## Testing
- `pytest tests/test_ir_convolution.py tests/test_oversample_tail.py tests/test_cli_ir_render.py tests/test_audio_render.py tests/test_ir_sr_channels.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_686efdba9ef88328a5ba0bce08c8a833