### PR TITLE
Refine arrangement utilities

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,8 @@
+# Project Architecture
+
+This project generates musical arrangements from YAML chord maps. Each section is
+rendered by individual part generators. The new `utilities.arrangement_builder`
+module merges these per-section parts into one track per generator while keeping
+section markers. CLI tools can convert the merged score to MIDI via
+`score_to_pretty_midi`.
+

--- a/tests/test_arrangement_builder.py
+++ b/tests/test_arrangement_builder.py
@@ -1,0 +1,20 @@
+from music21 import stream, note, instrument
+
+from utilities.arrangement_builder import build_arrangement, score_to_pretty_midi
+
+
+def _make_part(pitch: str) -> stream.Part:
+    p = stream.Part()
+    p.insert(0.0, instrument.Piano())
+    p.append(note.Note(pitch, quarterLength=1.0))
+    return p
+
+
+def test_track_count_matches_generators() -> None:
+    sections = [
+        ("Verse", 0.0, {"piano": _make_part("C4"), "drums": _make_part("C2")}),
+        ("Chorus", 4.0, {"piano": _make_part("D4"), "drums": _make_part("D2")}),
+    ]
+    score, generator_names = build_arrangement(sections)
+    pm = score_to_pretty_midi(score)
+    assert len(pm.instruments) == len(generator_names)

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -92,6 +92,19 @@ else:
         )
 
 if _HAS_MUSIC21:
+    from .arrangement_builder import build_arrangement, score_to_pretty_midi
+else:
+    def build_arrangement(*_args: Any, **_kwargs: Any) -> tuple[Any, list[str]]:
+        raise ModuleNotFoundError(
+            "music21 is required. Please run 'pip install -r requirements.txt'."
+        )
+
+    def score_to_pretty_midi(*_args: Any, **_kwargs: Any) -> Any:
+        raise ModuleNotFoundError(
+            "music21 is required. Please run 'pip install -r requirements.txt'."
+        )
+
+if _HAS_MUSIC21:
     from .scale_registry import ScaleRegistry, build_scale_object
 else:
     class ScaleRegistry:  # type: ignore[misc]
@@ -273,6 +286,8 @@ __all__ = [
     "render_wav",
     "render_part_audio",
     "EffectPresetLoader",
+    "build_arrangement",
+    "score_to_pretty_midi",
 ]
 
 

--- a/utilities/arrangement_builder.py
+++ b/utilities/arrangement_builder.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Iterable
+from copy import deepcopy
+import io
+
+from music21 import stream, expressions, instrument
+from music21.midi import translate
+import pretty_midi
+
+
+def _clone(elem: object) -> object:
+    """Return a safe clone of *elem*."""
+    try:
+        return elem.clone()
+    except Exception:
+        return deepcopy(elem)
+
+
+SectionParts = tuple[str, float, dict[str, stream.Part]]
+
+
+def build_arrangement(sections: Iterable[SectionParts]) -> tuple[stream.Score, list[str]]:
+    """Combine per-section parts into one part per generator.
+
+    Parameters
+    ----------
+    sections:
+        Iterable of ``(section_name, offset_q, parts)`` tuples. ``parts`` maps a
+        generator name to a ``music21`` ``Part`` representing that section.
+
+    Returns
+    -------
+    tuple[stream.Score, list[str]]
+        The merged score and ordered list of generator names.
+    """
+    combined: dict[str, stream.Part] = {}
+    generator_names: list[str] = []
+
+    for section_name, offset_q, parts in sections:
+        for gen_name, part in parts.items():
+            if gen_name not in combined:
+                dest = stream.Part(id=gen_name)
+                inst = part.getInstrument(returnDefault=False)
+                if inst is None:
+                    try:
+                        inst = instrument.fromString(gen_name)
+                    except Exception:
+                        inst = instrument.Instrument()
+                        inst.partName = gen_name
+                dest.insert(0.0, inst)
+                combined[gen_name] = dest
+                generator_names.append(gen_name)
+            else:
+                dest = combined[gen_name]
+
+            dest.insert(offset_q, expressions.TextExpression(section_name))
+            for elem in part:
+                if isinstance(elem, instrument.Instrument):
+                    continue
+                dest.insert(offset_q + elem.offset, _clone(elem))
+
+    score = stream.Score()
+    for name in generator_names:
+        score.insert(0, combined[name])
+    return score, generator_names
+
+
+def score_to_pretty_midi(score: stream.Score) -> pretty_midi.PrettyMIDI:
+    """Convert a ``music21`` score to ``pretty_midi``."""
+    mf = translate.streamToMidiFile(score)
+    data = mf.writestr()
+    return pretty_midi.PrettyMIDI(io.BytesIO(data))


### PR DESCRIPTION
## Summary
- improve type hints in arrangement builder
- document arrangement builder usage in architecture notes

## Testing
- `pytest tests/test_arrangement_builder.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f8c3cc99c832884209042dbd3da43