### PR TITLE
Fix MIDI track merging

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,3 +6,32 @@ module merges these per-section parts into one track per generator while keeping
 section markers. CLI tools can convert the merged score to MIDI via
 `score_to_pretty_midi`.
 
+## Part Integration Logic
+
+The `compose()` function assembles streams returned from every part generator.
+When multiple sections are processed, items with the same part ID are merged
+into a single `music21.stream.Part`.  Each event's offset is adjusted by the
+section start time before insertion, so the resulting part contains a continuous
+timeline across the entire song.  Instruments are inserted only once per part,
+and additional events from later sections simply extend the existing stream.
+
+## Studio One Track Layout
+
+Below is a simplified view of how the exported MIDI appears when imported into
+Studio&nbsp;One:
+
+```text
+Track 1  Piano          [Verse][Chorus][Bridge]
+Track 2  Bass           [Verse][Chorus][Bridge]
+Track 3  Drums          [Verse][Chorus][Bridge]
+```
+
+Each instrument occupies a single track across the song, matching the section
+order defined in the YAML chord map.
+
+## Future Direction
+
+The current integration logic will eventually move into an
+`ArrangementBuilder` class to centralize score assembly and prepare for more
+advanced editing features.
+

--- a/modular_composer.py
+++ b/modular_composer.py
@@ -106,7 +106,6 @@ def compose(
         )
 
     part_streams: dict[str, stream.Part] = {}
-    used_ids: set[str] = set()
 
     sections_to_gen: list[str] = main_cfg["sections_to_generate"]
     raw_sections: dict[str, dict[str, Any]] = chordmap.get("sections", {})
@@ -234,19 +233,7 @@ def compose(
 
                 fixed_items = []
                 for base_pid, sub_stream in items:
-                    pid = base_pid
-                    if pid in used_ids or pid == "":
-                        base = pid if pid else f"{part_name}_0"
-                        suffix = ""
-                        count = 0
-                        while True:
-                            candidate = base + suffix
-                            if candidate not in used_ids:
-                                pid = candidate
-                                break
-                            count += 1
-                            suffix = "_dup" if count == 1 else f"_dup{count}"
-                    used_ids.add(pid)
+                    pid = base_pid or f"{part_name}_0"
                     try:
                         if getattr(sub_stream, "id", None) in (None, ""):
                             sub_stream.id = pid

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,7 +1,9 @@
 import base64
 import asyncio
+import io
 
 import pytest
+import pretty_midi
 
 pytest.importorskip("pytest_asyncio")
 import httpx
@@ -20,6 +22,8 @@ async def test_generate_endpoint():
         data = resp.json()
         midi = base64.b64decode(data["midi"])
         assert midi.startswith(b"MThd")
+        pm = pretty_midi.PrettyMIDI(io.BytesIO(midi))
+        assert len(pm.instruments) == 1
 
 
 @pytest.mark.asyncio
@@ -34,3 +38,5 @@ async def test_websocket_broadcast():
     data = await asyncio.to_thread(run_ws)
     midi = base64.b64decode(data["midi"])
     assert midi.startswith(b"MThd")
+    pm = pretty_midi.PrettyMIDI(io.BytesIO(midi))
+    assert len(pm.instruments) == 1

--- a/tests/test_api_vocal_endpoints.py
+++ b/tests/test_api_vocal_endpoints.py
@@ -1,5 +1,6 @@
 import base64
 import asyncio
+import io
 
 import pytest
 
@@ -9,6 +10,7 @@ from httpx import AsyncClient
 from fastapi.testclient import TestClient
 
 from api import vocal_server as server
+import pretty_midi
 
 
 @pytest.mark.asyncio
@@ -23,6 +25,8 @@ async def test_generate_vocal_endpoint():
         data = resp.json()
         midi = base64.b64decode(data["midi"])
         assert midi.startswith(b"MThd")
+        pm = pretty_midi.PrettyMIDI(io.BytesIO(midi))
+        assert len(pm.instruments) == 1
 
 
 @pytest.mark.asyncio
@@ -37,3 +41,5 @@ async def test_ws_vocal_session_broadcast():
     data = await asyncio.to_thread(run_ws)
     midi = base64.b64decode(data["midi"])
     assert midi.startswith(b"MThd")
+    pm = pretty_midi.PrettyMIDI(io.BytesIO(midi))
+    assert len(pm.instruments) == 1


### PR DESCRIPTION
## Summary
- avoid renaming duplicate part IDs when assembling the score
- ensure multiple sections merge into a single instrument track
- add integration tests for merged tracks
- document current compose() merging and track layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68700d6baa8c83288d0b58c645a9dbec