### PR TITLE
Improve IR stereo mixing

### DIFF
--- a/tests/test_ir_sr_channels.py
+++ b/tests/test_ir_sr_channels.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.requires_audio
 
 
 @pytest.mark.parametrize("sr", [44100, 96000, 192000])
-@pytest.mark.parametrize("channels", [1, 2, 4])
+@pytest.mark.parametrize("channels", [1, 2, 3, 4, 5])
 def test_ir_sr_and_channels(tmp_path, monkeypatch, sr, channels):
     import utilities.convolver as conv
 
@@ -55,3 +55,16 @@ def test_downmix_none_preserves_channels(tmp_path, monkeypatch, sr):
     data, out_sr = sf.read(out, always_2d=True)
     assert out_sr == 44100
     assert data.shape[1] == 4
+
+
+@pytest.mark.parametrize("channels", [3, 5])
+def test_mix_to_stereo_rms_energy(channels):
+    import utilities.convolver as conv
+
+    ir = np.random.random((128, channels)).astype(np.float32)
+    stereo = conv._mix_to_stereo(ir)
+
+    assert stereo.shape == (128, 2)
+    orig_pow = float(np.sum(ir**2))
+    new_pow = float(np.sum(stereo**2))
+    assert np.allclose(new_pow, orig_pow)


### PR DESCRIPTION
## Summary
- implement RMS helper
- downmix multi-channel IRs using RMS weighting with energy normalization
- extend IR sampling tests for additional channels

## Testing
- `ruff check utilities/convolver.py tests/test_ir_sr_channels.py --fix`
- `mypy`
- `pytest tests/test_ir_sr_channels.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687054016af08328a86f83d1a231949e