### PR TITLE
Refactor render audio kwargs

### DIFF
--- a/tests/test_render_kwargs.py
+++ b/tests/test_render_kwargs.py
@@ -1,0 +1,36 @@
+import hashlib
+import warnings
+from pathlib import Path
+from music21 import stream, note
+from utilities import audio_render
+
+
+def _make_part():
+    p = stream.Part()
+    p.append(note.Note('C4', quarterLength=1))
+    return p
+
+
+def test_render_kwargs_deprecated_dict(tmp_path, monkeypatch):
+    part = _make_part()
+
+    def fake_render_wav(_mid, _ir, out, **_kw):
+        Path(out).write_bytes(b'X')
+        return Path(out)
+
+    monkeypatch.setattr(audio_render, "render_wav", fake_render_wav)
+
+    out1 = tmp_path / "a.wav"
+    out2 = tmp_path / "b.wav"
+
+    audio_render.render_part_audio(part, out_path=out1, quality="fast", bit_depth=24)
+    with warnings.catch_warnings(record=True) as w:
+        audio_render.render_part_audio(
+            part,
+            mix_opts={"out_path": out2, "quality": "fast", "bit_depth": 24},
+        )
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    h1 = hashlib.sha1(out1.read_bytes()).hexdigest()
+    h2 = hashlib.sha1(out2.read_bytes()).hexdigest()
+    assert h1 == h2

--- a/utilities/convolver.py
+++ b/utilities/convolver.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Any
+import warnings
 
 import numpy as np
 from music21 import stream
@@ -370,7 +372,7 @@ def render_wav(
     dither: bool = True,
     downmix: Literal["auto", "stereo", "none"] = "auto",
     tail_db_drop: float = -60.0,
-    **mix_opts,
+    **kw: Any,
 ) -> Path:
     """Render ``midi_path`` with ``fluidsynth`` and apply ``ir_path``."""
     from utilities.synth import render_midi
@@ -394,7 +396,15 @@ def render_wav(
 
     tmp = Path(out_path).with_suffix(".dry.wav")
     render_midi(midi_in, tmp, sf2_path=sf2)
-    mix_opts.pop("downmix", None)
+    if "mix_opts" in kw:
+        warnings.warn(
+            "'mix_opts' dict is deprecated; pass options as keyword arguments",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        mo = kw.pop("mix_opts") or {}
+        if isinstance(mo, Mapping):
+            kw.update(mo)
     render_with_ir(
         tmp,
         ir_path,
@@ -406,7 +416,7 @@ def render_wav(
         dither=dither,
         downmix=downmix,
         tail_db_drop=tail_db_drop,
-        **mix_opts,
+        **kw,
     )
     tmp.unlink(missing_ok=True)
     if tmp_midi is not None:


### PR DESCRIPTION
## Summary
- add kwargs compatibility shim for `render_part_audio`
- update `render_wav` in `convolver`
- add regression test covering deprecated dict use

## Testing
- `pytest tests/test_render_kwargs.py tests/test_audio_render.py::test_render_part_audio_options -q`

------
https://chatgpt.com/codex/tasks/task_e_6870544826408328988233ee3ef384e3