### PR TITLE
Fix tests for missing scikit-learn

### DIFF
--- a/tests/test_auto_tag_ngram.py
+++ b/tests/test_auto_tag_ngram.py
@@ -19,6 +19,7 @@ def _mk_loop(path: Path) -> None:
 
 @pytest.mark.data_ops
 def test_auto_tag_train(tmp_path: Path) -> None:
+    pytest.importorskip("sklearn", reason="scikit-learn not installed")
     _mk_loop(tmp_path / "a.mid")
     runner = CliRunner()
     out = tmp_path / "m.pkl"

--- a/tests/test_tone_shaper_fit.py
+++ b/tests/test_tone_shaper_fit.py
@@ -1,9 +1,11 @@
 import numpy as np
+import pytest
 
 from utilities.tone_shaper import ToneShaper
 
 
 def test_tone_shaper_fit_predict() -> None:
+    pytest.importorskip("sklearn", reason="scikit-learn not installed")
     shaper = ToneShaper()
     mfcc_clean = np.ones((13, 10))
     mfcc_drive = np.full((13, 10), 2.0)


### PR DESCRIPTION
## Summary
- skip `test_auto_tag_train` when scikit‑learn is unavailable
- skip tone shaper test if scikit‑learn is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870798c4dcc832887565988f9c89407