### PR TITLE
Fix test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ test = [
   "mido",
   "python-rtmidi",
   "hdbscan>=0.8",
+  "PyYAML>=6.0",
 ]
 audio = [
   "soundfile>=0.12",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,6 +7,7 @@ scikit-learn>=1.3
 mido>=1.3
 pretty_midi>=0.2
 websockets>=12.0  # test_ws_echo 用
+PyYAML>=6.0
 
 fastapi>=0.85
 httpx>=0.23


### PR DESCRIPTION
## Summary
- ensure PyYAML is installed for tests

## Testing
- `pytest tests/test_cli_groove_info.py tests/test_cli_playback_fallback.py tests/test_preview_fallback.py tests/test_sampler_cli_humanize.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687082dca8f8832881f4802b0665bad4