### PR TITLE
Fix CLI info command name

### DIFF
--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -1396,7 +1396,7 @@ def sample_cmd(
         sys.stdout.buffer.write(buf.getvalue())
 
 
-@cli.command()
+@cli.command(name="info")
 @click.argument("model_path", type=Path)
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON summary")
 @click.option("--stats", is_flag=True, help="Include perplexity and token count")


### PR DESCRIPTION
## Summary
- fix the `info` command registration in `groove_sampler_ngram`

## Testing
- `pytest tests/test_cli_groove_info.py::test_info_cmd -vv`

------
https://chatgpt.com/codex/tasks/task_e_6870a2fbeb648328852bc1dd2bc9e816