### PR TITLE
Fix stdout playback fallback

### DIFF
--- a/utilities/cli_playback.py
+++ b/utilities/cli_playback.py
@@ -120,3 +120,9 @@ def find_player() -> Optional[PlayFunc]:
         return _windows_player()
     return None
 
+
+def write_stdout(data: bytes) -> None:
+    """Write ``data`` to ``stdout`` in a Python-version agnostic way."""
+    out = getattr(sys.stdout, "buffer", sys.stdout)
+    out.write(data)
+

--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -1391,9 +1391,9 @@ def sample_cmd(
             player(data)
         else:
             logger.warning("no MIDI player found; writing to stdout")
-            sys.stdout.buffer.write(data)
+            cli_playback.write_stdout(data)
     else:
-        sys.stdout.buffer.write(buf.getvalue())
+        cli_playback.write_stdout(buf.getvalue())
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
- add `write_stdout` helper for binary-safe stdout writes
- use `write_stdout` in CLI sampler when player is absent

## Testing
- `pytest -q`
- `pytest tests/test_cli_playback_fallback.py::test_cli_playback_fallback -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a31441808328912c341315d47e8d