### PR TITLE
Fix optional dependency handling in rhythm loader

### DIFF
--- a/utilities/rhythm_library_loader.py
+++ b/utilities/rhythm_library_loader.py
@@ -9,8 +9,15 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Final, List, Literal, Optional, Union
 
-import yaml
-import tomli
+try:  # optional dependencies for YAML/TOML support
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+try:
+    import tomli
+except Exception:  # pragma: no cover - optional dependency
+    tomli = None
 
 try:
     from pydantic import BaseModel, Field, ValidationError, field_validator
@@ -287,8 +294,12 @@ def _parse_file(path: Path) -> Dict[str, Any]:
             if path.suffix.lower() == ".json":
                 return json.loads(content)
             elif path.suffix.lower() in {".yaml", ".yml"}:
+                if yaml is None:
+                    raise ImportError("PyYAML not installed")
                 return yaml.safe_load(content)
             elif path.suffix.lower() == ".toml":
+                if tomli is None:
+                    raise ImportError("tomli not installed")
                 return tomli.loads(content)
             else:
                 raise ValueError(f"Unsupported file format: {path.suffix}")


### PR DESCRIPTION
## Summary
- avoid immediate import errors in `rhythm_library_loader`
- ensure YAML and TOML parsers are optional

## Testing
- `pytest tests/test_sampler_cli_humanize.py::test_cli_humanize -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a367c4e88328b53ea44bfe2b5519