### PR TITLE
Fix MIDI playback fallback

### DIFF
--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -1388,7 +1388,11 @@ def sample_cmd(
         data = buf.getvalue()
         player = cli_playback.find_player()
         if player:
-            player(data)
+            try:
+                player(data)
+            except Exception as exc:  # pragma: no cover - best effort fallback
+                logger.warning("MIDI player failed: %s; writing to stdout", exc)
+                sys.stdout.buffer.write(data)
         else:
             logger.warning("no MIDI player found; writing to stdout")
             sys.stdout.buffer.write(data)


### PR DESCRIPTION
## Summary
- handle errors when attempting MIDI playback

## Testing
- `pytest tests/test_preview_fallback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a35645e48328b6b1be594882c4b6