### PR TITLE
Fix CLI sample command syntax

### DIFF
--- a/utilities/groove_sampler_ngram.py
+++ b/utilities/groove_sampler_ngram.py
@@ -1384,25 +1384,20 @@ def sample_cmd(
     pm = events_to_midi(ev)
     buf = io.BytesIO()
     pm.write(buf)
+    data = buf.getvalue()
     if play:
-        data = buf.getvalue()
         player = cli_playback.find_player()
         if player:
             try:
                 player(data)
             except Exception as exc:  # pragma: no cover - best effort fallback
                 logger.warning("MIDI player failed: %s; writing to stdout", exc)
-                sys.stdout.buffer.write(data)
+                cli_playback.write_stdout(data)
         else:
             logger.warning("no MIDI player found; writing to stdout")
-            sys.stdout.buffer.write(data)
-            sys.stdout.buffer.flush()
+            cli_playback.write_stdout(data)
     else:
-        sys.stdout.buffer.write(buf.getvalue())
-        sys.stdout.buffer.flush()
         cli_playback.write_stdout(data)
-    else:
-        cli_playback.write_stdout(buf.getvalue())
 
 
 @cli.command(name="info")


### PR DESCRIPTION
## Summary
- fix malformed else clause in the groove sampler CLI sample command

## Testing
- `pytest -q tests/test_live_stub.py::test_live_stub -s`
- `pytest -q` *(fails: ModuleNotFoundError: Missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6870aba9b78083289902544f2a7f01ae