### PR TITLE
refactor(harmonics): extract common helper, add CLI toggle & velocity utils

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -69,6 +69,8 @@ gen.export_musicxml_tab("out_tab.xml")
 gen = GuitarGenerator(enable_harmonics=True, prob_harmonic=0.25)
 ```
 
+You can disable harmonic generation from the CLI with `--no-harmonics`.
+
 Set ``prob_harmonic`` to ``1.0`` to force harmonics for testing.  Use
 ``harmonic_types`` to filter between natural or artificial nodes.
 

--- a/tests/test_harmonics_extended.py
+++ b/tests/test_harmonics_extended.py
@@ -1,7 +1,7 @@
 from music21 import pitch
 
 from generator.guitar_generator import GuitarGenerator
-from utilities.harmonic_utils import choose_harmonic
+from utilities.harmonic_utils import apply_harmonic_to_pitch, choose_harmonic
 
 
 def test_natural_5f_harmonic():
@@ -28,7 +28,18 @@ def test_artificial_harmonic():
         rng_seed=2,
     )
     p = pitch.Pitch("C4")
-    new, arts, _, _ = gen._maybe_harmonic(p, [p])
+    new, arts, _, _ = apply_harmonic_to_pitch(
+        p,
+        chord_pitches=[p],
+        tuning_offsets=gen.tuning,
+        base_midis=None,
+        max_fret=gen.max_harmonic_fret,
+        allowed_types=gen.harmonic_types,
+        rng=gen.rng,
+        prob=gen.prob_harmonic,
+        volume_factor=gen.harmonic_volume_factor,
+        gain_db=gen.harmonic_gain_db,
+    )
     assert int(round(new.midi)) == int(round(p.midi)) + 12
 
 
@@ -38,7 +49,7 @@ def test_base_midis_override():
         p,
         tuning_offsets=None,
         chord_pitches=[p],
-        base_midis=[60, 65, 70],
+        open_string_midis=[60, 65, 70],
     )
     assert result is not None
     _, meta = result

--- a/tests/test_harmonics_xml.py
+++ b/tests/test_harmonics_xml.py
@@ -1,0 +1,51 @@
+import xml.etree.ElementTree as ET
+
+
+def _basic_section():
+    return {
+        "section_name": "A",
+        "q_length": 1.0,
+        "humanized_duration_beats": 1.0,
+        "original_chord_label": "C",
+        "chord_symbol_for_voicing": "C",
+        "part_params": {},
+        "musical_intent": {},
+        "shared_tracks": {},
+    }
+
+
+def test_guitar_harmonic_xml(_basic_gen, tmp_path):
+    gen = _basic_gen(enable_harmonics=True, prob_harmonic=1.0, rng_seed=42)
+    part = gen.compose(section_data=_basic_section())
+    path = tmp_path / "g.xml"
+    gen.export_musicxml_tab(str(path))
+    tree = ET.parse(path)
+    root = tree.getroot()
+    assert root.findall(".//harmonic")
+    strings = [int(e.text) for e in root.findall(".//string")]
+    frets = [int(e.text) for e in root.findall(".//fret")]
+    assert strings and frets
+    first = part.flatten().notes[0]
+    meta = getattr(first, "harmonic_meta", None)
+    assert meta
+    assert meta["string_idx"] + 1 in strings
+    assert meta["touch_fret"] in frets
+
+
+def test_strings_harmonic_xml(_strings_gen, tmp_path):
+    gen = _strings_gen(enable_harmonics=True, prob_harmonic=1.0, rng_seed=99)
+    parts = gen.compose(section_data=_basic_section())
+    vio = parts["violin_i"]
+    path = tmp_path / "s.xml"
+    gen.export_musicxml(str(path))
+    root = ET.parse(path).getroot()
+    assert root.findall(".//harmonic")
+    strings = [int(e.text) for e in root.findall(".//string")]
+    frets = [int(e.text) for e in root.findall(".//fret")]
+    assert strings and frets
+    first = vio.flatten().notes[0]
+    meta = getattr(first, "harmonic_meta", None)
+    assert meta
+    assert meta["string_idx"] + 1 in strings
+    assert meta["touch_fret"] in frets
+

--- a/tests/test_velocity_utils.py
+++ b/tests/test_velocity_utils.py
@@ -1,0 +1,7 @@
+from utilities.velocity_utils import scale_velocity
+
+
+def test_scale_velocity_basic():
+    assert scale_velocity(100, 0.5) == 50
+    assert scale_velocity(120, 1.2) == 127
+    assert scale_velocity(1, 0.0) == 1

--- a/utilities/harmonic_utils.py
+++ b/utilities/harmonic_utils.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import random
 from collections.abc import Sequence
+from collections.abc import Sequence as SeqType
 
+from music21 import articulations, pitch
 from music21 import note as m21note
-from music21 import pitch
 
-_BASE_MIDIS = [40, 45, 50, 55, 59, 64]
+_BASE_MIDIS: list[int] = [40, 45, 50, 55, 59, 64]
 
-_NATURAL_INTERVALS = {5: 31, 7: 19, 12: 12}
+_NATURAL_INTERVALS: dict[int, int] = {5: 31, 7: 19, 12: 12}
 
 
 def choose_harmonic(
@@ -15,12 +17,12 @@ def choose_harmonic(
     tuning_offsets: Sequence[int] | None,
     chord_pitches: Sequence[pitch.Pitch] | None,
     max_fret: int = 19,
-    base_midis: Sequence[int] | None = None,
+    open_string_midis: Sequence[int] | None = None,
 ) -> tuple[pitch.Pitch, dict] | None:
     """Return a harmonic candidate for *base_pitch*.
 
     Natural nodes at the 5th, 7th and 12th fret are tried first.  ``tuning_offsets``
-    and ``base_midis`` describe the tuning and open-string pitches.  If none fit
+    and ``open_string_midis`` describe the tuning and open-string pitches.  If none fit
     within ``max_fret`` an artificial octave harmonic is attempted.  ``meta``
     describes the chosen string, type and sounding pitch.
     """
@@ -30,7 +32,7 @@ def choose_harmonic(
         return None
 
     tuning_offsets = list(tuning_offsets or [])
-    base_midis = list(base_midis or _BASE_MIDIS)
+    base_midis = list(open_string_midis or _BASE_MIDIS)
     open_midis: list[int] = []
     for i, m in enumerate(base_midis):
         offset = tuning_offsets[i] if i < len(tuning_offsets) else 0
@@ -94,3 +96,76 @@ def apply_harmonic_notation(
         n.harmonic_meta = meta
     except Exception:
         pass
+
+
+def apply_harmonic_to_pitch(
+    p: pitch.Pitch,
+    *,
+    chord_pitches: SeqType[pitch.Pitch],
+    tuning_offsets: SeqType[int] | None,
+    base_midis: SeqType[int] | None,
+    max_fret: int,
+    allowed_types: SeqType[str],
+    rng: random.Random,
+    prob: float,
+    volume_factor: float,
+    gain_db: float | None = None,
+) -> tuple[pitch.Pitch, list[articulations.Articulation], float, dict | None]:
+    """Maybe convert *p* into a harmonic pitch.
+
+    Returns the possibly modified pitch, articulation list, velocity factor and
+    harmonic metadata. If harmonics are not applied the original pitch is
+    returned with an empty articulation list and factor 1.0.
+    """
+    from music21 import articulations
+
+    if rng.random() >= prob:
+        return p, [], 1.0, None
+
+    result = choose_harmonic(
+        p,
+        tuning_offsets=tuning_offsets,
+        chord_pitches=list(chord_pitches),
+        max_fret=max_fret,
+        open_string_midis=list(base_midis) if base_midis is not None else None,
+    )
+    if result is None:
+        return p, [], 1.0, None
+    new_pitch, meta = result
+    if meta.get("type") not in allowed_types:
+        if "artificial" in allowed_types:
+            base_midi = int(round(p.midi))
+            open_midis = [
+                m + (tuning_offsets[i] if tuning_offsets and i < len(tuning_offsets) else 0)
+                for i, m in enumerate(base_midis or _BASE_MIDIS)
+            ]
+            for idx, open_m in enumerate(open_midis):
+                fret = base_midi - open_m
+                if 0 <= fret <= max_fret and fret + 12 <= max_fret:
+                    new_pitch = pitch.Pitch()
+                    new_pitch.midi = base_midi + 12
+                    meta = {
+                        "type": "artificial",
+                        "string_idx": idx,
+                        "touch_fret": fret + 12,
+                        "sounding_pitch": int(new_pitch.midi),
+                    }
+                    break
+            else:
+                return p, [], 1.0, None
+        else:
+            return p, [], 1.0, None
+
+    arts: list[articulations.Articulation] = [articulations.Harmonic()]
+    typ = meta.get("type")
+    if typ == "natural" and hasattr(articulations, "NaturalHarmonic"):
+        arts.append(articulations.NaturalHarmonic())
+    elif typ != "natural" and hasattr(articulations, "ArtificialHarmonic"):
+        arts.append(articulations.ArtificialHarmonic())
+    if typ != "natural" and hasattr(articulations, "TouchingPitch"):
+        arts.append(articulations.TouchingPitch())
+
+    factor = 10 ** (gain_db / 20) if gain_db is not None else volume_factor
+    if typ == "artificial":
+        factor *= 0.8
+    return new_pitch, arts, factor, meta

--- a/utilities/velocity_utils.py
+++ b/utilities/velocity_utils.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def scale_velocity(v: int | float, factor: float) -> int:
+    """Scale *v* by *factor* and clamp to MIDI velocity range."""
+    val = float(v) * factor
+    return max(1, min(127, int(round(val))))


### PR DESCRIPTION
## Summary
- share harmonic pitch logic between generators
- allow custom open-string MIDI tables
- expose velocity scaling helper
- add CLI flag for disabling harmonics
- document the new option
- test XML harmonic output and velocity scaling

## Testing
- `ruff check --fix utilities/harmonic_utils.py generator/guitar_generator.py generator/strings_generator.py utilities/velocity_utils.py tests/test_harmonics_xml.py tests/test_velocity_utils.py tests/test_harmonics_extended.py modular_composer.py`
- `mypy --strict`
- `pytest -q tests/test_harmonics_xml.py tests/test_velocity_utils.py tests/test_harmonics_extended.py` *(fails: Missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6871210b228c8328be099d7caa925bc3