### PR TITLE
Fix model saving and expose CC map

### DIFF
--- a/generator/strings_generator.py
+++ b/generator/strings_generator.py
@@ -53,7 +53,7 @@ from music21 import (
     instrument as m21instrument,
 )
 
-from utilities.cc_map import cc_map
+from utilities.cc_map import cc_map, load_cc_map
 from utilities.cc_tools import finalize_cc_events, merge_cc_events
 from utilities.core_music_utils import (
     get_key_signature_object,

--- a/utilities/groove_sampler_v2.py
+++ b/utilities/groove_sampler_v2.py
@@ -450,6 +450,7 @@ def save(model: NGramModel, path: Path) -> None:
         "ctx_maps": model.ctx_maps,
         "prob_paths": model.prob_paths,
     }
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("wb") as fh:
         pickle.dump(data, fh)
 


### PR DESCRIPTION
## Summary
- ensure output directory exists when saving n-gram models
- re-export `load_cc_map` from `strings_generator`

## Testing
- `pytest -q` *(fails: 5 failed, 562 passed, 93 skipped, 1 xpassed)*

------
https://chatgpt.com/codex/tasks/task_e_6871315050d4832891b9a7fa601754ed