### PR TITLE
Add recursive audio support for groove sampler

### DIFF
--- a/tests/test_groove_sampler_audio.py
+++ b/tests/test_groove_sampler_audio.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+import soundfile as sf
+from pathlib import Path
+
+from utilities import groove_sampler_v2
+
+pytestmark = pytest.mark.requires_audio
+
+
+def _make_kick_wav(path: Path) -> None:
+    sr = 16000
+    y = np.zeros(int(sr * 2), dtype=np.float32)
+    for i in range(4):
+        y[int(i * 0.5 * sr)] = 1.0
+    sf.write(path, y, sr)
+
+
+def test_train_with_audio(tmp_path: Path) -> None:
+    wav = tmp_path / "kick.wav"
+    _make_kick_wav(wav)
+    model = groove_sampler_v2.train(tmp_path, n=2)
+    assert len(model.idx_to_state) > 0


### PR DESCRIPTION
## Summary
- support recursive search and audio wav conversion in `groove_sampler_v2`
- add helper utilities for MIDI collection and WAV conversion
- expose `--no-audio` flag in CLI
- test training with WAV file

## Testing
- `mypy utilities/groove_sampler_v2.py`
- `pytest tests/test_groove_sampler_audio.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687270e7030c8328b2c0c8606d22a529