### PR TITLE
Fix GPU runner auth

### DIFF
--- a/.github/workflows/train-velocity-on-gpu.yml
+++ b/.github/workflows/train-velocity-on-gpu.yml
@@ -14,16 +14,13 @@ env:
 jobs:
   spawn-runner:
     runs-on: ubuntu-latest
+    env:
+      RUNPOD_API: ${{ secrets.RUNPOD_API }}
+      GH_TOKEN: ${{ secrets.GH_PAT_RUNNER }}
     outputs:
       pod_id: ${{ steps.spawn.outputs.pod_id }}
       ip: ${{ steps.info.outputs.ip }}
     steps:
-      - name: gh auth
-        env:
-          GH_PAT_RUNNER: ${{ secrets.GH_PAT_RUNNER }}
-        run: |
-          set -euo pipefail
-          echo "$GH_PAT_RUNNER" | gh auth login --with-token
       - id: spawn
         run: |
           set -euo pipefail
@@ -49,11 +46,13 @@ jobs:
             [[ "$ip" == "null" ]] && sleep 5
           done
           echo "ip=$ip" >> $GITHUB_OUTPUT
-      - id: token
+      - name: Get runner registration token
+        id: token
         run: |
-          set -euo pipefail
-          t=$(gh api -X POST repos/${{ github.repository }}/actions/runners/registration-token -q .token)
-          echo "token=$t" >> $GITHUB_OUTPUT
+          echo "token=$(gh api \
+            -X POST \
+            /repos/${{ github.repository }}/actions/runners/registration-token \
+            -q .token)" >> $GITHUB_OUTPUT
       - name: install-runner
         env:
           POD_ID: ${{ steps.spawn.outputs.pod_id }}


### PR DESCRIPTION
## Summary
- update train-velocity-on-gpu workflow
  - drop interactive `gh auth login`
  - use GH_TOKEN for API auth and fetch runner token non-interactively
  - set job-level env for RUNPOD_API and GH_TOKEN

## Testing
- `bash setup.sh` *(fails: installation incomplete)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'music21')*

------
https://chatgpt.com/codex/tasks/task_e_6872841e09908328a3e8bd35ce069137