### PR TITLE
Fix trailing newline in GPU workflow

### DIFF
--- a/.github/workflows/train-velocity-on-gpu.yml
+++ b/.github/workflows/train-velocity-on-gpu.yml
@@ -131,4 +131,3 @@ jobs:
             -H 'Content-Type: application/json' \
             -H "Authorization: $RUNPOD_API" \
             -d "{\"query\":\"mutation{podTerminate(podId:\\"$POD_ID\\")}\"}"
-


### PR DESCRIPTION
## Summary
- remove extraneous newline from the GPU training workflow

## Testing
- `pytest -q` *(fails: 8 failed, 562 passed, 95 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68729fa09ad88328aca25bf50077a060