### PR TITLE
Fix tests for harmonics and audio rendering

### DIFF
--- a/generator/guitar_generator.py
+++ b/generator/guitar_generator.py
@@ -1240,6 +1240,8 @@ class GuitarGenerator(BasePartGenerator):
                         )
                         if meta:
                             apply_harmonic_notation(n_in_ch_note, meta)
+                            if not hasattr(ch, "harmonic_meta"):
+                                ch.harmonic_meta = meta
                 if is_palm_muted:
                     n_in_ch_note.articulations.append(articulations.Staccatissimo())
             ch.offset = self._jitter(0.0)

--- a/utilities/harmonic_utils.py
+++ b/utilities/harmonic_utils.py
@@ -79,18 +79,16 @@ def apply_harmonic_notation(
     try:
         from music21 import articulations
 
-        if not hasattr(n, "notations") or n.notations is None:
-            n.notations = m21note.Notations()
         harm = articulations.StringHarmonic()
         harm.harmonicType = "artificial" if meta.get("type") != "natural" else "natural"
         harm.pitchType = "touching"
-        n.notations.append(harm)
+        n.articulations.append(harm)
         StringCls = getattr(articulations, "StringIndication", None)
         FretCls = getattr(articulations, "FretIndication", None)
         if StringCls:
-            n.notations.append(StringCls(number=int(meta["string_idx"]) + 1))
+            n.articulations.append(StringCls(number=int(meta["string_idx"]) + 1))
         if FretCls:
-            n.notations.append(FretCls(number=int(meta["touch_fret"])))
+            n.articulations.append(FretCls(number=int(meta["touch_fret"])))
         setattr(n, "string", meta.get("string_idx"))
         setattr(n, "fret", meta.get("touch_fret"))
         n.harmonic_meta = meta


### PR DESCRIPTION
## Summary
- ensure harmonic notation attaches correctly without music21 `Notations`
- store harmonic metadata on chords for XML tests
- provide fallback IR paths and synthesis for strings export
- allow `_SectionInfo` to omit `open_string_midi`
- add dummy mode for `MLVelocityModel` when torch isn't available

## Testing
- `pytest tests/test_harmonics_xml.py tests/test_ml_velocity_integration.py::test_ml_velocity_accuracy tests/test_strings_ir_render.py tests/test_strings_phase0.py::test_velocity_clamping -vv`

------
https://chatgpt.com/codex/tasks/task_e_6872f6729c488328ac427cd2008df9c4