### PR TITLE
Add dynamic resolution and sampling filters

### DIFF
--- a/docs/groove_sampler.md
+++ b/docs/groove_sampler.md
@@ -19,6 +19,21 @@ Generate a four bar MIDI groove:
 modcompose groove sample model.pkl -l 4 --temperature 0.8 --seed 42 > out.mid
 ```
 
+### New parameters
+
+``groove_sampler_v2`` exposes additional options:
+
+- ``--beats-per-bar``: override bar length when inferring resolution
+- ``--temperature-end``: final sampling temperature for scheduling
+- ``--top-k`` / ``--top-p``: filter sampling candidates
+
+Example:
+
+```bash
+groove_sampler_v2 train loops/ --auto-res --beats-per-bar 8
+groove_sampler_v2 sample model.pkl -l 4 --top-k 5 --top-p 0.8 > out.json
+```
+
 An experimental RNN baseline can be trained from the cached loops:
 
 ```bash

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -1,0 +1,54 @@
+import subprocess
+import sys
+from pathlib import Path
+import pretty_midi
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    for i in range(2):
+        start = i * 0.5
+        inst.notes.append(
+            pretty_midi.Note(velocity=100, pitch=36, start=start, end=start + 0.1)
+        )
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_cli_beats_per_bar_and_sampling(tmp_path: Path) -> None:
+    loops = tmp_path / "loops"
+    loops.mkdir()
+    _make_loop(loops / "a.mid")
+    model_path = tmp_path / "model.pkl"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "utilities.groove_sampler_v2",
+            "train",
+            str(loops),
+            "--auto-res",
+            "--beats-per-bar",
+            "8",
+            "-o",
+            str(model_path),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "utilities.groove_sampler_v2",
+            "sample",
+            str(model_path),
+            "--top-k",
+            "5",
+            "--top-p",
+            "0.8",
+        ],
+        check=True,
+        capture_output=True,
+    )
+

--- a/tests/test_infer_resolution.py
+++ b/tests/test_infer_resolution.py
@@ -1,0 +1,14 @@
+from utilities import groove_sampler
+
+
+def test_infer_resolution_beats_per_bar_int() -> None:
+    beats = [0.0, 1.0, 2.0]
+    res = groove_sampler.infer_resolution(beats, beats_per_bar=8)
+    assert res == 8
+
+
+def test_infer_resolution_beats_per_bar_half() -> None:
+    beats = [0.0, 0.5, 1.0]
+    res = groove_sampler.infer_resolution(beats, beats_per_bar=8)
+    assert res == 16
+

--- a/tests/test_resolution_multistage.py
+++ b/tests/test_resolution_multistage.py
@@ -1,0 +1,7 @@
+from utilities import groove_sampler
+
+def test_multistage_resolution() -> None:
+    beats = [0.0, 0.25, 0.5, 0.75, 1.0]
+    res = groove_sampler.infer_multistage_resolution(beats)
+    assert res['coarse'] <= res['fine']
+    assert res['coarse'] > 0 and res['fine'] > 0

--- a/tests/test_sampling_filters.py
+++ b/tests/test_sampling_filters.py
@@ -1,0 +1,33 @@
+import numpy as np
+from random import Random
+from utilities import groove_sampler_v2
+
+
+def _make_model() -> groove_sampler_v2.NGramModel:
+    freq = [ {0: np.array([6, 3, 1], dtype=np.uint32)} ]
+    bucket = {0: np.array([6, 3, 1], dtype=np.uint32)}
+    ctx = [{0: 0}]
+    prob = [np.array([[0.6, 0.3, 0.1]], dtype=np.float32)]
+    return groove_sampler_v2.NGramModel(
+        n=1,
+        resolution=16,
+        resolution_coarse=16,
+        state_to_idx={(0,0,'a'):0,(0,1,'b'):1,(0,2,'c'):2},
+        idx_to_state=[(0,0,'a'),(0,1,'b'),(0,2,'c')],
+        freq=freq,
+        bucket_freq=bucket,
+        ctx_maps=ctx,
+        prob_paths=None,
+        prob=prob,
+    )
+
+
+def test_topk_and_topp() -> None:
+    model = _make_model()
+    rng = Random(0)
+    results_k = {groove_sampler_v2.sample_next(model, [], 0, rng, top_k=1) for _ in range(20)}
+    assert results_k == {0}
+    rng = Random(0)
+    results_p = {groove_sampler_v2.sample_next(model, [], 0, rng, top_p=0.5) for _ in range(20)}
+    assert results_p == {0}
+

--- a/tests/test_temperature_schedule.py
+++ b/tests/test_temperature_schedule.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from utilities import groove_sampler_v2
+import pretty_midi
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    for i in range(4):
+        start = i * 0.25
+        inst.notes.append(pretty_midi.Note(velocity=100, pitch=36, start=start, end=start + 0.05))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_temperature_schedule(tmp_path: Path, monkeypatch) -> None:
+    _make_loop(tmp_path / "a.mid")
+    model = groove_sampler_v2.train(tmp_path)
+    temps: list[float] = []
+    orig = groove_sampler_v2.sample_next
+
+    def wrapper(*args, temperature: float, **kwargs):
+        temps.append(temperature)
+        return orig(*args, temperature=temperature, **kwargs)
+
+    monkeypatch.setattr(groove_sampler_v2, "sample_next", wrapper)
+    groove_sampler_v2.generate_events(model, bars=1, temperature=1.0, temperature_end=0.5, seed=0)
+    assert temps[0] == 1.0
+    assert temps[-1] <= 0.55
+


### PR DESCRIPTION
## Summary
- extend sampler training with `beats_per_bar`
- implement top-k and top-p sampling filters with temperature scheduling
- support new CLI options for training and sampling
- document new parameters in `groove_sampler.md`
- add unit tests for resolution, temperature schedule and sampling filters

## Testing
- `pytest tests/test_infer_resolution.py tests/test_temperature_schedule.py tests/test_sampling_filters.py tests/test_cli_options.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872fdd3be7c8328955da85631bd0d84