### PR TITLE
Add CLI export and render features

### DIFF
--- a/docs/groove_sampler.md
+++ b/docs/groove_sampler.md
@@ -59,3 +59,15 @@ in version 1.0 and ignores auxiliary conditions.
 
 Models generated prior to commit 608fdda no longer include the
 deprecated `aux_dims` field and should be retrained.
+
+## CLI Commands
+
+| Command | Description | Key options |
+| ------- | ----------- | ----------- |
+| `groove train` | Train n-gram model from loops | `--ext`, `--out` |
+| `groove sample` | Generate groove MIDI | `-l`, `--temperature`, `--seed` |
+| `export-midi` | Save sampled MIDI to file | `--length`, `--temperature`, `--seed` |
+| `render-audio` | Convert MIDI to audio with FluidSynth | `--out`, `--soundfont`, `--use-default-sf2` |
+| `evaluate` | Calculate basic groove metrics | `--ref` |
+| `visualize` | Draw n-gram frequency heatmap | `--out` |
+| `hyperopt` | Optuna search over temperature | `--trials`, `--skip-if-no-optuna` |

--- a/tests/test_cli_hyperopt.py
+++ b/tests/test_cli_hyperopt.py
@@ -1,0 +1,53 @@
+import json
+import sys
+from types import SimpleNamespace
+import builtins
+
+from click.testing import CliRunner
+
+import modular_composer.cli as cli
+
+
+class DummyStudy:
+    def __init__(self, best):
+        self.best_params = best
+
+    def optimize(self, func, n_trials):
+        pass
+
+
+def test_cli_hyperopt(monkeypatch):
+    best = {"temperature": 0.9}
+    fake_optuna = SimpleNamespace(create_study=lambda direction="maximize": DummyStudy(best), Trial=None)
+    monkeypatch.setitem(sys.modules, "optuna", fake_optuna)
+    monkeypatch.setattr(cli.groove_sampler_ngram, "load", lambda p: object())
+    monkeypatch.setattr(cli.groove_sampler_ngram, "sample", lambda mdl, bars, temperature: [{"velocity": 0}])
+    runner = CliRunner()
+    res = runner.invoke(cli.cli, ["hyperopt", "dummy.pkl", "--trials", "2"])
+    assert res.exit_code == 0
+    assert json.loads(res.output) == best
+
+
+def test_hyperopt_skip(monkeypatch):
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "optuna":
+            raise ImportError("no optuna")
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    runner = CliRunner()
+    res = runner.invoke(
+        cli.cli,
+        ["hyperopt", "dummy.pkl", "--skip-if-no-optuna"],
+    )
+    assert res.exit_code == 0
+    assert res.output == ""
+
+
+def test_hyperopt_in_help():
+    runner = CliRunner()
+    res = runner.invoke(cli.cli, ["--help"])
+    assert res.exit_code == 0
+    assert "hyperopt" in res.output

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -1,0 +1,72 @@
+import json
+from pathlib import Path
+
+import pretty_midi
+from click.testing import CliRunner
+
+import modular_composer.cli as cli
+from utilities import groove_sampler_ngram as gs
+
+
+def _make_loop(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    for i in range(4):
+        start = i * 0.25
+        inst.notes.append(pretty_midi.Note(velocity=100, pitch=36, start=start, end=start + 0.1))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_cli_export_midi(tmp_path: Path) -> None:
+    loops = tmp_path / "loops"
+    loops.mkdir()
+    _make_loop(loops / "a.mid")
+    model = gs.train(loops, order=1)
+    gs.save(model, tmp_path / "model.pkl")
+    out = tmp_path / "out.mid"
+    runner = CliRunner()
+    res = runner.invoke(cli.cli, ["export-midi", str(tmp_path / "model.pkl"), str(out)])
+    assert res.exit_code == 0
+    assert out.exists()
+
+
+def test_cli_render_audio(tmp_path: Path, monkeypatch) -> None:
+    midi = tmp_path / "a.mid"
+    midi.write_bytes(b"MThd\x00\x00\x00\x06\x00\x01\x00\x01\x00\x60MTrk\x00\x00\x00\x04\x00\xFF\x2F\x00")
+    out = tmp_path / "out.wav"
+    runner = CliRunner()
+    monkeypatch.setattr(cli, "has_fluidsynth", lambda: True)
+    monkeypatch.setattr(cli.synth, "export_audio", lambda *a, **k: out.write_bytes(b""))
+    res = runner.invoke(
+        cli.cli,
+        ["render-audio", str(midi), "-o", str(out), "--use-default-sf2"],
+    )
+    assert res.exit_code == 0
+    assert out.exists()
+
+
+def test_cli_evaluate(tmp_path: Path) -> None:
+    ref = tmp_path / "ref.mid"
+    gen = tmp_path / "gen.mid"
+    _make_loop(ref)
+    _make_loop(gen)
+    runner = CliRunner()
+    res = runner.invoke(cli.cli, ["evaluate", str(gen), "--ref", str(ref)])
+    assert res.exit_code == 0
+    data = json.loads(res.output)
+    assert "swing_score" in data
+    assert "blec" in data
+
+
+def test_cli_visualize(tmp_path: Path) -> None:
+    loops = tmp_path / "loops"
+    loops.mkdir()
+    _make_loop(loops / "a.mid")
+    model = gs.train(loops, order=1)
+    gs.save(model, tmp_path / "model.pkl")
+    out = tmp_path / "plot.png"
+    runner = CliRunner()
+    res = runner.invoke(cli.cli, ["visualize", str(tmp_path / "model.pkl"), "--out", str(out)])
+    assert res.exit_code == 0
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add CLI commands for `export-midi`, `render-audio`, `evaluate`, `visualize`, and `hyperopt`
- implement simple Optuna search and heatmap visualisation
- expose new commands via modular_composer CLI
- add tests covering new commands
- add hyperopt CLI test
- extend render-audio with default soundfont flag and check for fluidsynth
- add skip-if-no-optuna flag for hyperopt
- document CLI commands table

## Testing
- `pytest tests/test_cli_hyperopt.py tests/test_cli_new_features.py tests/test_cli_fx.py tests/test_cli_groove_info.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873194b769c8328ad73fff0a99bbb71