### PR TITLE
Add MIDI load timeout with size guard

### DIFF
--- a/tests/test_loop_ingest.py
+++ b/tests/test_loop_ingest.py
@@ -92,3 +92,20 @@ def test_scan_auto_aux(tmp_path: Path) -> None:
     assert meta["low.mid"] == "low"
     assert meta["mid.mid"] == "mid"
     assert meta["high.mid"] == "high"
+
+
+def _make_long_midi(path: Path) -> None:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    inst.notes.append(pretty_midi.Note(velocity=100, pitch=36, start=0.0, end=601.0))
+    pm.instruments.append(inst)
+    pm.write(str(path))
+
+
+def test_scan_skips_large_midi(tmp_path: Path) -> None:
+    _make_long_midi(tmp_path / "big.mid")
+    _make_midi(tmp_path / "small.mid", 36)
+    data = scan_loops(tmp_path, exts=["mid"])
+    files = {d["file"] for d in data}
+    assert "big.mid" not in files
+    assert "small.mid" in files


### PR DESCRIPTION
## Summary
- add `_load_pretty_midi` helper with timeout and size checks
- skip files that exceed 10s to load, 600s length or 32 tracks
- unit test to ensure large MIDI files are skipped

## Testing
- `pip install music21 pretty_midi mido`
- `pip install scipy soundfile librosa pytest pytest-cov scikit-learn`
- `pytest tests/test_loop_ingest.py::test_scan_skips_large_midi -q`

------
https://chatgpt.com/codex/tasks/task_e_68733afa11e08328920aa7115aec98b2