### PR TITLE
Improve train_velocity CLI overrides

### DIFF
--- a/scripts/train_velocity.py
+++ b/scripts/train_velocity.py
@@ -4,26 +4,26 @@ import argparse
 import sys
 from pathlib import Path
 
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument("--epochs", type=int)
 parser.add_argument("--out", type=str)
+parser.add_argument("--run-dir", type=str)
+
+if "-h" in sys.argv or "--help" in sys.argv:
+    parser.print_help()
+    print()
+
 parsed_args, remaining_argv = parser.parse_known_args()
 sys.argv = sys.argv[:1] + remaining_argv
 extra_overrides: list[str] = []
 if parsed_args.epochs is not None:
     extra_overrides.append(f"training.epochs={parsed_args.epochs}")
 if parsed_args.out is not None:
-    cfg_file = Path(__file__).resolve().parent.parent / "configs" / "velocity_model.yaml"
-    try:
-        base_cfg = OmegaConf.load(cfg_file)
-    except Exception:
-        base_cfg = {}
-    if isinstance(base_cfg, DictConfig) and "out" in base_cfg:
-        extra_overrides.append(f"out.ckpt={parsed_args.out}")
-    else:
-        extra_overrides.append(f"+out={parsed_args.out}")
+    extra_overrides.append(f"+out={parsed_args.out}")
+if parsed_args.run_dir is not None:
+    extra_overrides.append(f"hydra.run.dir={parsed_args.run_dir}")
 if extra_overrides:
     sys.argv += extra_overrides
 


### PR DESCRIPTION
## Summary
- simplify CLI overrides for train_velocity
- add `--run-dir` option
- ensure Hydra help shows with script help

## Testing
- `bash setup.sh` *(fails to install dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'music21')*

------
https://chatgpt.com/codex/tasks/task_e_6873b3bf9ebc8328b299da6578e811e5