### PR TITLE
Ensure sampler dependencies installed

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,17 @@
 #!/bin/bash
 set -e
+
+# Install the main requirements
 pip install -r requirements.txt
+
+# Ensure frequently missed tools are present.  These are needed for
+# the groove sampler utilities and other scripts.  If they are already
+# installed the commands below are a no-op.
+python - <<'EOF'
+import importlib.util, subprocess, sys
+missing = [pkg for pkg in ("pretty_midi", "tqdm")
+           if importlib.util.find_spec(pkg) is None]
+if missing:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", *missing])
+EOF
+


### PR DESCRIPTION
## Summary
- add a post-install check in `setup.sh` so that `pretty_midi` and `tqdm` are always available

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c0d265a88328aeb145f8c4b17bd6