### PR TITLE
Add tempo-map MIDI export utility

### DIFF
--- a/tests/test_midi_export.py
+++ b/tests/test_midi_export.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pretty_midi
+
+from utilities.midi_export import export_song
+
+
+def stub_generator(bars: int, tempo: float) -> pretty_midi.PrettyMIDI:
+    pm = pretty_midi.PrettyMIDI(initial_tempo=tempo)
+    inst = pretty_midi.Instrument(program=0, is_drum=True)
+    inst.notes.append(pretty_midi.Note(start=0.0, end=0.5, pitch=36, velocity=100))
+    pm.instruments.append(inst)
+    return pm
+
+
+def test_export_song(tmp_path: Path) -> None:
+    tempo_map = [(0, 120), (8, 90), (16, 140)]
+    out = tmp_path / "song.mid"
+    pm = export_song(
+        32, tempo_map=tempo_map, generators={"drum": stub_generator}, out_path=out
+    )
+    assert out.exists()
+    assert len(pm.instruments) == 1
+    assert len(pm._tick_scales) == 3

--- a/utilities/midi_export.py
+++ b/utilities/midi_export.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import copy
+import csv
+import importlib
+import io
+import json
 from collections.abc import Callable
 from pathlib import Path
-import io
 
 try:  # pragma: no cover - optional dependency for export helpers
     import mido
@@ -67,3 +71,106 @@ def music21_to_mido(part: stream.Part) -> "mido.MidiFile":
         append_extra_cc(part, midi.tracks[0], to_ticks)
     return midi
 
+
+def apply_tempo_map(
+    pm: "pretty_midi.PrettyMIDI", tempo_map: list[tuple[float, float]] | None
+) -> None:
+    """Apply a tempo map to ``pm`` using PrettyMIDI's private API."""
+    if tempo_map is None:
+        return
+    pm._tick_scales = []
+    for beat, bpm in tempo_map:
+        pm._tick_scales.append(
+            (
+                int(round(float(beat) * pm.resolution)),
+                60.0 / (float(bpm) * pm.resolution),
+            )
+        )
+
+
+def export_song(
+    bars: int,
+    *,
+    tempo_map: list[tuple[float, float]] | None = None,
+    generators: dict[str, Callable[[int, float], "pretty_midi.PrettyMIDI"]],
+    fixed_tempo: float = 120.0,
+    out_path: str | Path = "song.mid",
+) -> "pretty_midi.PrettyMIDI":
+    """Generate multiple parts and export a merged MIDI file."""
+
+    out_path = Path(out_path)
+    child_pms: list["pretty_midi.PrettyMIDI"] = []
+    for name, gen in (generators or {}).items():
+        pm = gen(bars, fixed_tempo)
+        apply_tempo_map(pm, tempo_map)
+        child_pms.append(pm)
+
+    master = pretty_midi.PrettyMIDI(initial_tempo=fixed_tempo)
+    for pm in child_pms:
+        for inst in pm.instruments:
+            master.instruments.append(copy.deepcopy(inst))
+
+    apply_tempo_map(master, tempo_map)
+    master.write(str(out_path))
+    return master
+
+
+def _load_tempo_map(path: Path) -> list[tuple[float, float]]:
+    if path.suffix.lower() == ".csv":
+        with path.open() as fh:
+            reader = csv.reader(fh)
+            return [(float(b), float(t)) for b, t in reader]
+    with path.open() as fh:
+        data = json.load(fh)
+    return [(float(b), float(t)) for b, t in data]
+
+
+def _import_generator(path: str) -> Callable[[int, float], "pretty_midi.PrettyMIDI"]:
+    mod = importlib.import_module(path)
+    return getattr(mod, "generate")
+
+
+def main(argv: list[str] | None = None) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Export MIDI song")
+    parser.add_argument("bars", type=int)
+    parser.add_argument("--tempo-map", dest="tempo_map")
+    parser.add_argument("--out", default="song.mid")
+    parser.add_argument("--fixed-t", type=float, default=120.0)
+    parser.add_argument(
+        "--drum",
+        default="generator.drum_generator",
+        help="import path to drum generator",
+    )
+    parser.add_argument("--bass")
+    parser.add_argument("--piano")
+
+    args = parser.parse_args(argv)
+
+    gens: dict[str, Callable[[int, float], "pretty_midi.PrettyMIDI"]] = {}
+    if args.drum:
+        gens["drum"] = _import_generator(args.drum)
+    if args.bass:
+        gens["bass"] = _import_generator(args.bass)
+    if args.piano:
+        gens["piano"] = _import_generator(args.piano)
+
+    tempo = None
+    if args.tempo_map:
+        tempo = _load_tempo_map(Path(args.tempo_map))
+
+    export_song(
+        args.bars,
+        tempo_map=tempo,
+        generators=gens,
+        fixed_tempo=args.fixed_t,
+        out_path=args.out,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI wrapper
+    main()
+
+
+__all__ = ["export_song", "apply_tempo_map"]


### PR DESCRIPTION
## Summary
- support merging generator outputs with tempo maps
- provide CLI for tempo-map export
- test midi export integration

## Testing
- `isort utilities/midi_export.py tests/test_midi_export.py`
- `black utilities/midi_export.py tests/test_midi_export.py`
- `pytest tests/test_midi_export.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873df339ca083288d909163cd62e093