### PR TITLE
Add dynamic fill density lookup for DrumGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ though the notes are correct. You can switch mappings programmatically via
 | II–V build-up         | `approach_style_on_4th`   | `approach_style_on_4th: subdom_dom`              |
 | Velocity envelope     | `velocity_envelope`       | `velocity_envelope: [[0.0,60],[2.0,90]]`         |
 
+## Lyric-responsive drum fills
+
+DrumGenerator now adjusts fill density based on the emotional intensity of each
+section.  The mapping from intensity (0–1) to fill density can be customized via
+`drum.fill_density_lut` in the YAML configuration.  Higher intensity sections
+produce richer fills automatically.
+
 ## Advanced Guitar Features
 
 | Feature | Parameter | Effect |

--- a/tests/test_drum_fill_density.py
+++ b/tests/test_drum_fill_density.py
@@ -1,0 +1,50 @@
+import random
+import pytest
+from generator.drum_generator import DrumGenerator
+
+@pytest.fixture()
+def drum():
+    cfg = {"global_settings": {"tempo_bpm": 120}}
+    return DrumGenerator(main_cfg=cfg, part_name="drums")
+
+@pytest.mark.parametrize(
+    "intensity,expected",
+    [
+        (0.0, 0.05),
+        (0.3, 0.15),
+        (0.75, 0.44375),
+        (1.0, 0.60),
+    ],
+)
+def test_fill_density_interp(drum, intensity, expected):
+    assert abs(drum.fill_density(intensity) - expected) < 1e-3
+
+
+def test_emotional_fill_calls(monkeypatch):
+    cfg = {"rng_seed": 0}
+    d = DrumGenerator(main_cfg=cfg, part_name="drums")
+    calls = []
+    def fake_insert(self, part, section, fill_key=None):
+        calls.append(1)
+
+    monkeypatch.setattr(
+        type(d.fill_inserter), "insert", fake_insert, raising=False
+    )
+    section = {
+        "absolute_offset": 0.0,
+        "q_length": 8.0,
+        "length_in_measures": 2,
+        "musical_intent": {"emotion_intensity": 0.2},
+        "part_params": {},
+    }
+    d.rng.seed(0)
+    for _ in range(10):
+        d.compose(section_data=section)
+    low = len(calls)
+    calls.clear()
+    section["musical_intent"] = {"emotion_intensity": 0.8}
+    d.rng.seed(0)
+    for _ in range(10):
+        d.compose(section_data=section)
+    high = len(calls)
+    assert high > low


### PR DESCRIPTION
## Summary
- implement intensity-driven drum fill density with interpolation LUT
- expose `fill_density_lut` and new helper methods
- insert emotional fills based on calculated density
- document lyric-responsive fills in README
- add unit tests for fill density calculations

## Testing
- `pytest tests/test_drum_fill_density.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687442c345a483288a3072559647952a