### PR TITLE
Add progression template loader and tests

### DIFF
--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -660,7 +660,7 @@ class DrumGenerator(BasePartGenerator):
         logger.info(
             f"DrumGen __init__: Initialized with {len(self.raw_pattern_lib)} raw drum patterns."
         )
-        self.fill_inserter = FillInserter(self.raw_pattern_lib)
+        self.fill_inserter: FillInserter = FillInserter(self.raw_pattern_lib)
         self.fill_inserter.drum_map = self.drum_map
         core_defaults = {
             "default_drum_pattern": {

--- a/tests/test_progression_templates.py
+++ b/tests/test_progression_templates.py
@@ -1,0 +1,38 @@
+import importlib
+from pathlib import Path
+import pytest
+
+# 1) ベーシック取得
+
+def test_basic_lookup(tmp_path):
+    """YAML から emotion+mode で Progression が取れる."""
+    yaml_file = tmp_path / "progs.yaml"
+    yaml_file.write_text(
+        "soft_reflective:\n"
+        "  major:\n"
+        "    - 'I V vi IV'\n"
+        "  minor:\n"
+        "    - 'i VII VI VII'\n"
+    )
+    mod = importlib.import_module("utilities.progression_templates")
+    lst = mod.get_progressions("soft_reflective", mode="major", path=yaml_file)
+    assert lst == ["I V vi IV"]
+
+# 2) キャッシュ確認 (lru_cache)
+
+def test_cache_identity(tmp_path):
+    yaml_file = tmp_path / "progs.yaml"
+    yaml_file.write_text("dummy: {}\n")
+    mod = importlib.import_module("utilities.progression_templates")
+    id1 = id(mod._load(path=yaml_file))
+    id2 = id(mod._load(path=yaml_file))
+    assert id1 == id2, "lru_cache should return same dict instance"
+
+# 3) エラー系
+@pytest.mark.parametrize("bucket, mode", [("missing", "major"), ("soft_reflective", "dorian")])
+def test_key_error(tmp_path, bucket, mode):
+    yaml_file = tmp_path / "progs.yaml"
+    yaml_file.write_text("soft_reflective:\n  major: ['I IV V']\n")
+    import utilities.progression_templates as pt
+    with pytest.raises(KeyError):
+        pt.get_progressions(bucket, mode=mode, path=yaml_file)

--- a/utilities/progression_templates.py
+++ b/utilities/progression_templates.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_PATH = Path(__file__).with_name("progression_templates.yaml")
+
+
+@lru_cache()
+def _load(path: str | Path = DEFAULT_PATH) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    with p.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Progression template file must contain a mapping")
+    return data
+
+
+def get_progressions(bucket: str, *, mode: str = "major", path: str | Path = DEFAULT_PATH) -> list[str]:
+    data = _load(path=path)
+    try:
+        modes = data[bucket]
+        return list(modes[mode])
+    except KeyError as exc:
+        raise KeyError(bucket, mode) from exc
+    except Exception as exc:
+        raise


### PR DESCRIPTION
## Summary
- implement `utilities.progression_templates` loader with LRU cache
- type annotate `fill_inserter` in `DrumGenerator`
- add pytest coverage for progression template lookups

## Testing
- `pytest tests/test_progression_templates.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68744922a6388328a16467483c6f4563