### PR TITLE
fail early on empty phrase datasets

### DIFF
--- a/scripts/train_phrase.py
+++ b/scripts/train_phrase.py
@@ -517,6 +517,14 @@ def train_model(
         len(val_rows),
         val_removed,
     )
+    if not train_rows:
+        raise ValueError(
+            f"training CSV produced no usable rows (kept {len(train_rows)} removed {tr_removed})"
+        )
+    if not val_rows:
+        raise ValueError(
+            f"validation CSV produced no usable rows (kept {len(val_rows)} removed {val_removed})"
+        )
     section_vals = {r["section"] for r in train_rows + val_rows if r.get("section")}
     mood_vals = {r["mood"] for r in train_rows + val_rows if r.get("mood")}
     instrument_vals = {r["instrument"] for r in train_rows + val_rows if r.get("instrument")}
@@ -1086,45 +1094,49 @@ def main(argv: list[str] | None = None) -> int:
     run_cfg["viz_enabled"] = bool(args.viz and plt is not None)
     run_cfg["viz_backend"] = plt.get_backend() if run_cfg["viz_enabled"] else None
 
-    f1, device_type, stats = train_model(
-        args.train_csv,
-        args.val_csv,
-        args.epochs,
-        args.arch,
-        args.out,
-        seed=args.seed,
-        batch_size=args.batch_size,
-        d_model=args.d_model,
-        max_len=args.max_len,
-        num_workers=args.num_workers,
-        pin_memory=args.pin_memory,
-        grad_clip=args.grad_clip,
-        lr=args.lr,
-        weight_decay=args.weight_decay,
-        scheduler=args.scheduler,
-        warmup_steps=args.warmup_steps,
-        pos_weight=args.pos_weight,
-        auto_pos_weight=args.auto_pos_weight,
-        resume=args.resume,
-        save_every=args.save_every,
-        early_stopping=args.early_stopping,
-        f1_scan_range=args.f1_scan_range,
-        logdir=args.logdir,
-        precision=args.precision,
-        deterministic=args.deterministic,
-        reweight=args.reweight,
-        lr_patience=args.lr_patience,
-        lr_factor=args.lr_factor,
-        use_duv_embed=args.use_duv_embed,
-        instrument=args.instrument,
-        include_tags=include,
-        exclude_tags=exclude,
-        viz=args.viz,
-        strict_tags=args.strict_tags,
-        nhead=args.nhead,
-        layers=args.layers,
-        dropout=args.dropout,
-    )
+    try:
+        f1, device_type, stats = train_model(
+            args.train_csv,
+            args.val_csv,
+            args.epochs,
+            args.arch,
+            args.out,
+            seed=args.seed,
+            batch_size=args.batch_size,
+            d_model=args.d_model,
+            max_len=args.max_len,
+            num_workers=args.num_workers,
+            pin_memory=args.pin_memory,
+            grad_clip=args.grad_clip,
+            lr=args.lr,
+            weight_decay=args.weight_decay,
+            scheduler=args.scheduler,
+            warmup_steps=args.warmup_steps,
+            pos_weight=args.pos_weight,
+            auto_pos_weight=args.auto_pos_weight,
+            resume=args.resume,
+            save_every=args.save_every,
+            early_stopping=args.early_stopping,
+            f1_scan_range=args.f1_scan_range,
+            logdir=args.logdir,
+            precision=args.precision,
+            deterministic=args.deterministic,
+            reweight=args.reweight,
+            lr_patience=args.lr_patience,
+            lr_factor=args.lr_factor,
+            use_duv_embed=args.use_duv_embed,
+            instrument=args.instrument,
+            include_tags=include,
+            exclude_tags=exclude,
+            viz=args.viz,
+            strict_tags=args.strict_tags,
+            nhead=args.nhead,
+            layers=args.layers,
+            dropout=args.dropout,
+        )
+    except ValueError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 2
 
     run_cfg["sampler_weights_summary"] = stats
     run_cfg["tag_coverage"] = stats.get("tag_coverage", {})

--- a/tests/test_train_phrase_cli_empty.py
+++ b/tests/test_train_phrase_cli_empty.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_empty(tmp_path: Path) -> None:
+    header = "pitch,velocity,duration,pos,boundary,bar\n"
+    train_csv = tmp_path / "train.csv"
+    val_csv = tmp_path / "val.csv"
+    train_csv.write_text(header)
+    val_csv.write_text(header)
+    repo_root = Path(__file__).resolve().parents[1]
+    code = (
+        "from tests.torch_stub import _stub_torch; _stub_torch();"
+        "from types import ModuleType;"
+        "import sys;"
+        "pt=ModuleType('models.phrase_transformer');"
+        "pt.PhraseTransformer=type('PhraseTransformer', (), {});"
+        "sys.modules.setdefault('models', ModuleType('models'));"
+        "sys.modules['models.phrase_transformer']=pt;"
+        "import runpy;"
+        f"sys.argv=['scripts/train_phrase.py','{train_csv}','{val_csv}','--epochs','1','--out','out.ckpt'];"
+        "runpy.run_path('scripts/train_phrase.py', run_name='__main__')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    assert result.returncode != 0
+    assert "produced no usable rows" in result.stderr

--- a/tests/test_train_phrase_empty_dataset.py
+++ b/tests/test_train_phrase_empty_dataset.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from .torch_stub import _stub_torch
+
+
+_stub_torch()
+
+pt = ModuleType("models.phrase_transformer")
+
+
+class PhraseTransformer:  # pragma: no cover - simple stub
+    pass
+
+
+pt.PhraseTransformer = PhraseTransformer
+sys.modules.setdefault("models", ModuleType("models"))
+sys.modules["models.phrase_transformer"] = pt
+
+from scripts.train_phrase import train_model
+
+
+def _write_csv(path: Path, rows: list[str]) -> None:
+    path.write_text("pitch,velocity,duration,pos,boundary,bar\n" + "\n".join(rows))
+
+
+def test_empty_training_dataset(tmp_path: Path) -> None:
+    train_csv = tmp_path / "train.csv"
+    val_csv = tmp_path / "val.csv"
+    _write_csv(train_csv, [])
+    _write_csv(val_csv, [])
+    with pytest.raises(ValueError, match="training CSV produced no usable rows"):
+        train_model(train_csv, val_csv, epochs=1, arch="lstm", out=tmp_path / "out.ckpt")
+
+
+def test_empty_validation_dataset(tmp_path: Path) -> None:
+    train_csv = tmp_path / "train.csv"
+    val_csv = tmp_path / "val.csv"
+    _write_csv(train_csv, ["60,64,1,0,0,1"])
+    _write_csv(val_csv, [])
+    with pytest.raises(ValueError, match="validation CSV produced no usable rows"):
+        train_model(train_csv, val_csv, epochs=1, arch="lstm", out=tmp_path / "out.ckpt")
+

--- a/tests/torch_stub.py
+++ b/tests/torch_stub.py
@@ -1,0 +1,95 @@
+import importlib
+import math
+import sys
+from types import ModuleType
+
+
+def _stub_torch() -> None:
+    if importlib.util.find_spec("torch") is not None:
+        return
+
+    class Tensor(list):
+        def unsqueeze(self, dim: int = 0) -> "Tensor":  # pragma: no cover - simple
+            if dim != 0:
+                raise NotImplementedError
+            return Tensor([list(self)])
+
+        def tolist(self) -> list:
+            return list(self)
+
+    def tensor(data, dtype=None):  # type: ignore[override]
+        return Tensor(data if isinstance(data, list) else [data])
+
+    def arange(n: int, dtype=None) -> Tensor:
+        return Tensor(list(range(n)))
+
+    def ones(*shape: int, dtype=None) -> Tensor:
+        def build(dims):
+            if len(dims) == 1:
+                return [1] * dims[0]
+            return [build(dims[1:]) for _ in range(dims[0])]
+
+        return Tensor(build(list(shape)))
+
+    def sigmoid(t: Tensor) -> Tensor:
+        def apply(x):
+            if isinstance(x, list):
+                return [apply(i) for i in x]
+            return 1 / (1 + math.exp(-x))
+
+        return Tensor(apply(t))
+
+    class NoGrad:
+        def __enter__(self) -> None:  # pragma: no cover - stub
+            pass
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - stub
+            pass
+
+    torch = ModuleType("torch")
+    torch.Tensor = Tensor
+    torch.tensor = tensor
+    torch.arange = arange
+    torch.ones = ones
+    torch.sigmoid = sigmoid
+    torch.no_grad = NoGrad
+    torch.float32 = float
+    torch.long = int
+    torch.bool = bool
+    torch.manual_seed = lambda _seed: None  # pragma: no cover - stub
+    torch.get_float32_matmul_precision = lambda: "medium"
+
+    class _Device:
+        def __init__(self, kind: str) -> None:
+            self.type = kind
+
+    torch.device = lambda kind: _Device(kind)
+
+    cuda = ModuleType("torch.cuda")
+    cuda.is_available = lambda: False
+    cuda.amp = ModuleType("torch.cuda.amp")
+    cuda.amp.GradScaler = lambda *a, **k: None
+    torch.cuda = cuda
+
+    backends = ModuleType("torch.backends")
+    mps = ModuleType("torch.backends.mps")
+    mps.is_available = lambda: False
+    backends.mps = mps
+    torch.backends = backends
+
+    nn = ModuleType("torch.nn")
+    nn.Module = object
+    torch.nn = nn
+
+    utils = ModuleType("torch.utils")
+    data = ModuleType("torch.utils.data")
+    data.DataLoader = object
+    data.Dataset = object
+    utils.data = data
+    torch.utils = utils
+
+    sys.modules["torch"] = torch
+    sys.modules["torch.nn"] = nn
+    sys.modules["torch.utils"] = utils
+    sys.modules["torch.utils.data"] = data
+


### PR DESCRIPTION
## Summary
- guard against empty training/validation CSVs in `train_phrase.py`
- share lightweight torch stub across tests and verify both empty dataset cases
- clarify error messages with kept/removed counts and catch errors at CLI entry
- add regression test that CLI exits non-zero on empty datasets

## Testing
- `pytest -q tests/test_controls_spline.py tests/test_apply_controls.py tests/test_audio_to_midi_batch_apply_controls.py tests/test_train_phrase_empty_dataset.py tests/test_train_phrase_cli_empty.py`
- `pre-commit run --files scripts/train_phrase.py tests/test_train_phrase_cli_empty.py tests/test_train_phrase_empty_dataset.py` *(command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa7d83a3483289576ab00c2f86b65